### PR TITLE
feat: make procedures async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "async-scoped"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7a6a57c8aeb40da1ec037f5d455836852f7a57e69e1b1ad3d8f38ac1d6cadf"
-dependencies = [
- "futures",
- "pin-project",
- "slab",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,28 +53,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -94,34 +66,6 @@ name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -141,13 +85,9 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -219,26 +159,6 @@ name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
-
-[[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -332,7 +252,6 @@ dependencies = [
 name = "rpc-rust"
 version = "0.1.0"
 dependencies = [
- "async-scoped",
  "async-trait",
  "futures-channel",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ async-trait = "0.1.57"
 protoc-rust = "2.27.1"
 
 [dev-dependencies]
-async-scoped = { version = "0.7.1", features = ["use-tokio", "tokio"]}
 protoc-rust = "2.27.1"
 
 

--- a/examples/integration/codegen/mod.rs
+++ b/examples/integration/codegen/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use protobuf::Message;
 use rpc_rust::{server::RpcServerPort, types::ServiceModuleDefinition};
 
@@ -8,8 +10,9 @@ use crate::{
 
 pub const SERVICE: &str = "BookService";
 
+#[async_trait::async_trait]
 pub trait BookServiceInterface {
-    fn get_book(&self, request: GetBookRequest, context: &MyExampleContext) -> Book;
+    async fn get_book(&self, request: GetBookRequest, context: Arc<MyExampleContext>) -> Book;
 }
 
 pub struct BookServiceCodeGen {}
@@ -21,10 +24,18 @@ impl BookServiceCodeGen {
     ) {
         println!("> BookServiceCodeGen > register_service");
         let mut service_def = ServiceModuleDefinition::new();
+        // Share service ownership
+        let service = Arc::new(service);
         service_def.add_definition("GetBook".to_string(), move |request, context| {
-            let res = service.get_book(GetBookRequest::parse_from_bytes(request).unwrap(), context);
-            println!("> Service Definition > Get Book > response: {:?}", res);
-            res.write_to_bytes().unwrap()
+            let req = Vec::from(request);
+            let serv = service.clone();
+            Box::pin(async move {
+                let res = serv
+                    .get_book(GetBookRequest::parse_from_bytes(&req).unwrap(), context)
+                    .await;
+                println!("> Service Definition > Get Book > response: {:?}", res);
+                res.write_to_bytes().unwrap()
+            })
         });
         port.register_module(SERVICE.to_string(), service_def)
     }

--- a/examples/integration/codegen/mod.rs
+++ b/examples/integration/codegen/mod.rs
@@ -3,23 +3,23 @@ use std::sync::Arc;
 use protobuf::Message;
 use rpc_rust::{server::RpcServerPort, types::ServiceModuleDefinition};
 
-use crate::{
-    service::api::{Book, GetBookRequest},
-    MyExampleContext,
-};
+use crate::service::api::{Book, GetBookRequest};
 
 pub const SERVICE: &str = "BookService";
 
 #[async_trait::async_trait]
-pub trait BookServiceInterface {
-    async fn get_book(&self, request: GetBookRequest, context: Arc<MyExampleContext>) -> Book;
+pub trait BookServiceInterface<Context> {
+    async fn get_book(&self, request: GetBookRequest, context: Arc<Context>) -> Book;
 }
 
 pub struct BookServiceCodeGen {}
 
 impl BookServiceCodeGen {
-    pub fn register_service<S: BookServiceInterface + Send + Sync + 'static>(
-        port: &mut RpcServerPort<MyExampleContext>,
+    pub fn register_service<
+        S: BookServiceInterface<Context> + Send + Sync + 'static,
+        Context: Send + Sync + 'static,
+    >(
+        port: &mut RpcServerPort<Context>,
         service: S,
     ) {
         println!("> BookServiceCodeGen > register_service");

--- a/examples/integration/codegen/mod.rs
+++ b/examples/integration/codegen/mod.rs
@@ -28,11 +28,10 @@ impl BookServiceCodeGen {
         // Share service ownership
         let service = Arc::new(service);
         service_def.add_definition("GetBook".to_string(), move |request, context| {
-            let req = Vec::from(request);
             let serv = service.clone();
             Box::pin(async move {
                 let res = serv
-                    .get_book(GetBookRequest::parse_from_bytes(&req).unwrap(), context)
+                    .get_book(GetBookRequest::parse_from_bytes(&request).unwrap(), context)
                     .await;
                 println!("> Service Definition > Get Book > response: {:?}", res);
                 res.write_to_bytes().unwrap()

--- a/examples/integration/codegen/mod.rs
+++ b/examples/integration/codegen/mod.rs
@@ -27,8 +27,10 @@ impl BookServiceCodeGen {
         let mut service_def = ServiceModuleDefinition::new();
         // Share service ownership
         let service = Arc::new(service);
+        // Clone it for "GetBook" procedure
+        let serv = Arc::clone(&service);
         service_def.add_definition("GetBook".to_string(), move |request, context| {
-            let serv = service.clone();
+            let serv = serv.clone();
             Box::pin(async move {
                 let res = serv
                     .get_book(GetBookRequest::parse_from_bytes(&request).unwrap(), context)

--- a/examples/integration/codegen/mod.rs
+++ b/examples/integration/codegen/mod.rs
@@ -1,3 +1,4 @@
+// THIS CODE SHOULD BE AUTO-GENERATED
 use std::sync::Arc;
 
 use protobuf::Message;

--- a/examples/integration/main.rs
+++ b/examples/integration/main.rs
@@ -50,119 +50,119 @@ async fn main() {
         .run()
         .expect("Running protoc failed.");
 
-    async_scoped::TokioScope::scope_and_block(|scope| {
-        // 1- Create Transport
-        let (mut client_transport, server_transport) =
-            transports::memory::MemoryTransport::create();
+    // 1- Create Transport
+    let (mut client_transport, server_transport) = transports::memory::MemoryTransport::create();
 
-        scope.spawn(async move {
-            let connect_message = vec![0];
-            client_transport.send(connect_message).await.unwrap();
+    let client_handle = tokio::spawn(async move {
+        let connect_message = vec![0];
+        client_transport.send(connect_message).await.unwrap();
 
-            let create_port = CreatePort {
-                message_identifier: build_message_identifier(5, 1),
-                port_name: "testport".to_string(),
-                ..Default::default()
-            };
+        let create_port = CreatePort {
+            message_identifier: build_message_identifier(5, 1),
+            port_name: "testport".to_string(),
+            ..Default::default()
+        };
 
-            let _result = client_transport
-                .send(create_port.write_to_bytes().unwrap())
-                .await;
+        let _result = client_transport
+            .send(create_port.write_to_bytes().unwrap())
+            .await;
 
-            // Wait for the server response
-            let res = client_transport.receive().await.unwrap();
-            println!("> Create Port > Server Response Type: {:?}", res);
-            match res {
-                TransportEvent::Message(bytes) => {
-                    let port_response = CreatePortResponse::parse_from_bytes(&bytes).unwrap();
-                    println!("> Create Port > Server Response body: {:?}", port_response)
-                }
-                _ => {
-                    println!("> Create Port > Server Response not message type")
-                }
+        // Wait for the server response
+        let res = client_transport.receive().await.unwrap();
+        println!("> Create Port > Server Response Type: {:?}", res);
+        match res {
+            TransportEvent::Message(bytes) => {
+                let port_response = CreatePortResponse::parse_from_bytes(&bytes).unwrap();
+                println!("> Create Port > Server Response body: {:?}", port_response)
             }
-
-            let request_module = RequestModule {
-                port_id: 1,
-                message_identifier: build_message_identifier(7, 2),
-                module_name: "BookService".to_string(),
-                ..Default::default()
-            };
-
-            let _result = client_transport
-                .send(request_module.write_to_bytes().unwrap())
-                .await;
-
-            let res = client_transport.receive().await.unwrap();
-
-            println!("> Request Module > Server Response Type: {:?}", res);
-            match res {
-                TransportEvent::Message(bytes) => {
-                    let request_module_response =
-                        RequestModuleResponse::parse_from_bytes(&bytes).unwrap();
-                    println!(
-                        "> Request Module > Server Response body: {:?}",
-                        request_module_response
-                    )
-                }
-                _ => {
-                    println!("> Request Module > Server Response not message type")
-                }
+            _ => {
+                println!("> Create Port > Server Response not message type")
             }
+        }
 
-            let mut get_book_payload = GetBookRequest::default();
-            get_book_payload.set_isbn(1000);
+        let request_module = RequestModule {
+            port_id: 1,
+            message_identifier: build_message_identifier(7, 2),
+            module_name: "BookService".to_string(),
+            ..Default::default()
+        };
 
-            let call_procedure = Request {
-                port_id: 1,
-                message_identifier: build_message_identifier(1, 3),
-                procedure_id: 1,
-                payload: get_book_payload.write_to_bytes().unwrap(),
-                ..Default::default()
-            };
+        let _result = client_transport
+            .send(request_module.write_to_bytes().unwrap())
+            .await;
 
-            let _result = client_transport
-                .send(call_procedure.write_to_bytes().unwrap())
-                .await;
+        let res = client_transport.receive().await.unwrap();
 
-            let res = client_transport.receive().await.unwrap();
-
-            println!("> Call Procedure > Server Response Type: {:?}", res);
-            match res {
-                TransportEvent::Message(bytes) => {
-                    let procedure_response = Response::parse_from_bytes(&bytes).unwrap();
-                    let payload = api::Book::parse_from_bytes(&procedure_response.payload).unwrap();
-                    println!(
-                        "> Call Procedure > Server Response body: {:?}",
-                        procedure_response
-                    );
-                    println!(
-                        "> Call Procedure > Server Response body > payload: {:?}",
-                        payload
-                    )
-                }
-                _ => {
-                    println!("> Call Procedure > Server Response not message type")
-                }
+        println!("> Request Module > Server Response Type: {:?}", res);
+        match res {
+            TransportEvent::Message(bytes) => {
+                let request_module_response =
+                    RequestModuleResponse::parse_from_bytes(&bytes).unwrap();
+                println!(
+                    "> Request Module > Server Response body: {:?}",
+                    request_module_response
+                )
             }
-        });
+            _ => {
+                println!("> Request Module > Server Response not message type")
+            }
+        }
 
-        scope.spawn(async {
-            let ctx = MyExampleContext {
-                hardcoded_database: create_db(),
-            };
+        let mut get_book_payload = GetBookRequest::default();
+        get_book_payload.set_isbn(1000);
 
-            // 2- Create Server with Transport
-            let mut server = RpcServer::create(ctx);
-            // 3- Server listen to Create Port request
-            server.set_handler(|port: &mut RpcServerPort<MyExampleContext>| {
-                println!("Port {} created!", port.name);
-                codegen::BookServiceCodeGen::register_service(port, book_service::BookService {})
-            });
+        let call_procedure = Request {
+            port_id: 1,
+            message_identifier: build_message_identifier(1, 3),
+            procedure_id: 1,
+            payload: get_book_payload.write_to_bytes().unwrap(),
+            ..Default::default()
+        };
 
-            server.attach_transport(server_transport);
+        let _result = client_transport
+            .send(call_procedure.write_to_bytes().unwrap())
+            .await;
 
-            server.run().await;
-        });
+        let res = client_transport.receive().await.unwrap();
+
+        println!("> Call Procedure > Server Response Type: {:?}", res);
+        match res {
+            TransportEvent::Message(bytes) => {
+                let procedure_response = Response::parse_from_bytes(&bytes).unwrap();
+                let payload = api::Book::parse_from_bytes(&procedure_response.payload).unwrap();
+                println!(
+                    "> Call Procedure > Server Response body: {:?}",
+                    procedure_response
+                );
+                println!(
+                    "> Call Procedure > Server Response body > payload: {:?}",
+                    payload
+                )
+            }
+            _ => {
+                println!("> Call Procedure > Server Response not message type")
+            }
+        }
     });
+
+    let server_handle = tokio::spawn(async {
+        let ctx = MyExampleContext {
+            hardcoded_database: create_db(),
+        };
+
+        // 2- Create Server with Transport
+        let mut server = RpcServer::create(ctx);
+        // 3- Server listen to Create Port request
+        server.set_handler(|port: &mut RpcServerPort<MyExampleContext>| {
+            println!("Port {} created!", port.name);
+            codegen::BookServiceCodeGen::register_service(port, book_service::BookService {})
+        });
+
+        server.attach_transport(server_transport);
+
+        server.run().await;
+    });
+
+    client_handle.await.unwrap();
+    server_handle.await.unwrap();
 }

--- a/examples/integration/service/book_service.rs
+++ b/examples/integration/service/book_service.rs
@@ -9,7 +9,7 @@ use super::api::Book;
 pub struct BookService {}
 
 #[async_trait::async_trait]
-impl BookServiceInterface for BookService {
+impl BookServiceInterface<MyExampleContext> for BookService {
     async fn get_book(
         &self,
         request: super::api::GetBookRequest,

--- a/examples/integration/service/book_service.rs
+++ b/examples/integration/service/book_service.rs
@@ -1,21 +1,30 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::time::sleep;
+
 use crate::{codegen::BookServiceInterface, MyExampleContext};
 
 use super::api::Book;
 
 pub struct BookService {}
 
+#[async_trait::async_trait]
 impl BookServiceInterface for BookService {
-    fn get_book(
+    async fn get_book(
         &self,
         request: super::api::GetBookRequest,
-        ctx: &MyExampleContext,
+        ctx: Arc<MyExampleContext>,
     ) -> super::api::Book {
         assert_eq!(ctx.hardcoded_database.len(), 2);
 
+        // Simulate DB operation
+        println!("> BookService > async get_book > simulating DB operation");
+        sleep(Duration::from_secs(1)).await;
         let book = ctx
             .hardcoded_database
             .iter()
             .find(|book_record| book_record.isbn == request.isbn);
+        println!("> BookService > async get_book > awaited DB operation");
 
         book.map(Book::clone).unwrap_or_default()
     }

--- a/examples/integration/service/book_service.rs
+++ b/examples/integration/service/book_service.rs
@@ -10,7 +10,7 @@ impl BookServiceInterface for BookService {
         request: super::api::GetBookRequest,
         ctx: &MyExampleContext,
     ) -> super::api::Book {
-        assert_eq!(ctx.hardcoded_database.len(), 1);
+        assert_eq!(ctx.hardcoded_database.len(), 2);
 
         let book = ctx
             .hardcoded_database

--- a/src/server.rs
+++ b/src/server.rs
@@ -374,7 +374,7 @@ impl<Context> RpcServerPort<Context> {
     }
 
     /// It will look up the procedure id in the port's `procedures` and execute the procedure's handler
-    pub async fn call_procedure(
+    async fn call_procedure(
         &self,
         procedure_id: u32,
         payload: Vec<u8>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -309,7 +309,7 @@ pub struct RpcServerPort<Context> {
 }
 
 impl<Context> RpcServerPort<Context> {
-    pub fn new(name: String) -> Self {
+    fn new(name: String) -> Self {
         RpcServerPort {
             name,
             registered_modules: HashMap::new(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -381,7 +381,7 @@ impl<Context> RpcServerPort<Context> {
         context: Arc<Context>,
     ) -> ServerResult<Vec<u8>> {
         match self.procedures.get(&procedure_id) {
-            Some(procedure_handler) => Ok(procedure_handler(&payload, context).await),
+            Some(procedure_handler) => Ok(procedure_handler(payload, context).await),
             _ => Err(ServerError::ProcedureError),
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, pin::Pin, sync::Arc};
 pub type UnaryRequestHandler<Context> =
     dyn Fn(Vec<u8>, Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
 
-#[derive(Default)]
 pub struct ServiceModuleDefinition<Context> {
     definitions: HashMap<String, Arc<UnaryRequestHandler<Context>>>,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,10 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use core::future::Future;
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 
-pub type UnaryRequestHandler<Context> = dyn Fn(&[u8], &Context) -> Vec<u8> + Send + Sync;
+pub type UnaryRequestHandler<Context> =
+    dyn Fn(&[u8], &Context) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
 
 #[derive(Default)]
 pub struct ServiceModuleDefinition<Context> {
-    definitions: HashMap<String, Arc<Box<UnaryRequestHandler<Context>>>>,
+    definitions: HashMap<String, Arc<UnaryRequestHandler<Context>>>,
 }
 
 impl<Context> ServiceModuleDefinition<Context> {
@@ -14,15 +16,20 @@ impl<Context> ServiceModuleDefinition<Context> {
         }
     }
 
-    pub fn add_definition<H: Fn(&[u8], &Context) -> Vec<u8> + Send + Sync + 'static>(
+    pub fn add_definition<
+        H: Fn(&[u8], &Context) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >(
         &mut self,
         name: String,
         handler: H,
     ) {
-        self.definitions.insert(name, Arc::new(Box::new(handler)));
+        self.definitions.insert(name, Arc::new(handler));
     }
 
-    pub fn get_definitions(&self) -> &HashMap<String, Arc<Box<UnaryRequestHandler<Context>>>> {
+    pub fn get_definitions(&self) -> &HashMap<String, Arc<UnaryRequestHandler<Context>>> {
         &self.definitions
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,7 +2,7 @@ use core::future::Future;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 pub type UnaryRequestHandler<Context> =
-    dyn Fn(&[u8], Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
+    dyn Fn(Vec<u8>, Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
 
 #[derive(Default)]
 pub struct ServiceModuleDefinition<Context> {
@@ -17,7 +17,7 @@ impl<Context> ServiceModuleDefinition<Context> {
     }
 
     pub fn add_definition<
-        H: Fn(&[u8], Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
+        H: Fn(Vec<u8>, Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
             + Send
             + Sync
             + 'static,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,7 +2,7 @@ use core::future::Future;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 pub type UnaryRequestHandler<Context> =
-    dyn Fn(&[u8], &Context) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
+    dyn Fn(&[u8], Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
 
 #[derive(Default)]
 pub struct ServiceModuleDefinition<Context> {
@@ -17,7 +17,7 @@ impl<Context> ServiceModuleDefinition<Context> {
     }
 
     pub fn add_definition<
-        H: Fn(&[u8], &Context) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
+        H: Fn(&[u8], Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
             + Send
             + Sync
             + 'static,


### PR DESCRIPTION
This PR: 
- **make service's procedures async** 
- `UnaryRequestHandler` receives owned `Vec<u8>` as payload instead of a `&[u8]`
- `RpcServer` Context is `Arc<Context>` now and cloned for each procedure call
- remove the `async-scoped` crate from the example
- codegen example uses generics instead of an explicit type