### PR TITLE
feat: add web sockets transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+**/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,10 +31,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -58,12 +79,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -85,6 +135,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -129,12 +194,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -145,6 +258,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "libc"
@@ -196,6 +315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +331,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -266,6 +397,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +455,19 @@ dependencies = [
  "protobuf",
  "protoc-rust",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -342,6 +515,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +579,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,10 +604,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "async-trait",
  "futures-channel",
  "futures-util",
+ "log",
  "protobuf",
  "protoc-rust",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 async-trait = "0.1.57"
 async-channel = "1.8.0"
 tokio-util = "0.7.4"
+tokio-tungstenite = "*"
 
 [build-dependencies]
 protoc-rust = "2.27.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1.57"
 async-channel = "1.8.0"
 tokio-util = "0.7.4"
 tokio-tungstenite = "*"
+log = "0.4.17"
 
 [build-dependencies]
 protoc-rust = "2.27.1"

--- a/examples/integration/main.rs
+++ b/examples/integration/main.rs
@@ -6,7 +6,7 @@ mod service;
 use rpc_rust::{
     client::RpcClient,
     server::{RpcServer, RpcServerPort},
-    transports::{self, memory::MemoryTransport, web_socket::WebSocketTransport},
+    transports::{self, memory::MemoryTransport, web_socket::WebSocketTransport, Transport},
 };
 
 use service::{api::Book, book_service};
@@ -66,10 +66,16 @@ async fn main() {
         .run()
         .expect("Running protoc failed.");
 
-    // 1- Create Transport
-    let (client_transport, server_transport) = create_web_socket_transports().await;
-    //let (client_transport, server_transport) = create_memory_transports();
+    println!("--- Running example with Memory Transports ---");
+    run_with_transports(create_memory_transports()).await;
 
+    println!("--- Running example with Web Socket Transports ---");
+    run_with_transports(create_web_socket_transports().await).await;
+}
+
+async fn run_with_transports<T: Transport + Send + Sync + 'static>(
+    (client_transport, server_transport): (T, T),
+) {
     let client_handle = tokio::spawn(async move {
         let mut client = RpcClient::new(client_transport).await.unwrap();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use log::{error, debug};
 use protobuf::Message;
 use tokio::{
     select,
@@ -236,7 +237,7 @@ impl ClientRequestDispatcher {
         tokio::spawn(async move {
             select! {
                 _ = token.cancelled() => {
-                    println!("> ClientRequestDispatcher cancelled!")
+                    debug!("> ClientRequestDispatcher cancelled!")
                 },
                 _ = this.process() => {
 
@@ -263,13 +264,11 @@ impl ClientRequestDispatcher {
                             match sender.map(|sender| sender.send(data)) {
                                 Some(Ok(_)) => {}
                                 Some(Err(_)) => {
-                                    println!(
-                                        "> Client > Error on sending message through transport"
-                                    );
+                                    error!("> Client > Error on sending message through transport");
                                     continue;
                                 }
                                 None => {
-                                    println!(
+                                    debug!(
                                         "> Client > No callback registered for message {} response",
                                         message_header.1
                                     );
@@ -278,7 +277,7 @@ impl ClientRequestDispatcher {
                             }
                         }
                         None => {
-                            println!("> Client > Error on parsing message header");
+                            debug!("> Client > Error on parsing message header");
                             continue;
                         }
                     }
@@ -288,7 +287,7 @@ impl ClientRequestDispatcher {
                     continue;
                 }
                 Err(_) => {
-                    println!("Client error on receiving");
+                    error!("Client error on receiving");
                     break;
                 }
             }
@@ -302,7 +301,7 @@ impl ClientRequestDispatcher {
         let (payload, current_request_message_id) = {
             let mut message_lock = self.next_message_id.lock().await;
             let message_id = *message_lock;
-            println!("Message ID: {}", message_id);
+            debug!("Message ID: {}", message_id);
             let payload = cb(message_id);
             // store next_message_id
             *message_lock += 1;

--- a/src/server.rs
+++ b/src/server.rs
@@ -76,12 +76,6 @@ impl<Context> RpcServer<Context> {
             {
                 Ok(event) => match event {
                     TransportEvent::Connect => {
-                        self.transport
-                            .as_mut()
-                            .expect("No transport attached")
-                            .connected()
-                            .await;
-                        println!("Transport connected");
                         // Response back to the client to finally establish the connection
                         // on both ends
                         self.transport

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc, u8};
 
+use log::{error, debug};
 use protobuf::{Message, RepeatedField};
 
 use crate::{
@@ -85,18 +86,18 @@ impl<Context> RpcServer<Context> {
                             .await
                             .expect("expect to be able to connect");
                     }
-                    TransportEvent::Error(err) => println!("Transport error {}", err),
+                    TransportEvent::Error(err) => error!("Transport error {}", err),
                     TransportEvent::Message(payload) => match self.handle_message(payload).await {
-                        Ok(_) => println!("Transport message handled!"),
-                        Err(e) => println!("Failed to handle message: {:?}", e),
+                        Ok(_) => debug!("Transport message handled!"),
+                        Err(e) => error!("Failed to handle message: {:?}", e),
                     },
                     TransportEvent::Close => {
-                        println!("Transport closed");
+                        error!("Transport closed");
                         break;
                     }
                 },
                 Err(_) => {
-                    println!("Transport error");
+                    error!("Transport error");
                     break;
                 }
             }
@@ -299,7 +300,7 @@ impl<Context> RpcServer<Context> {
                 // noops
             }
             _ => {
-                println!("Unknown message");
+                debug!("Unknown message");
             }
         };
 

--- a/src/transports/memory.rs
+++ b/src/transports/memory.rs
@@ -36,11 +36,11 @@ impl Transport for MemoryTransport {
     async fn receive(&self) -> Result<TransportEvent, TransportError> {
         match self.receiver.recv().await {
             Ok(event) => {
-                if event.len() == 1 && event[0] == 0 && !self.is_connected() {
+                let message = self.message_to_transport_event(event);
+                if let TransportEvent::Connect = message {
                     self.connected.store(true, Ordering::SeqCst);
-                    return Ok(TransportEvent::Connect);
                 }
-                Ok(TransportEvent::Message(event))
+                Ok(message)
             }
             Err(_) => {
                 self.close().await;

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 pub mod memory;
+pub mod web_socket;
 
 #[derive(Debug)]
 pub enum TransportEvent {
@@ -30,6 +31,5 @@ pub trait Transport {
     async fn receive(&self) -> Result<TransportEvent, TransportError>;
     async fn send(&self, message: Vec<u8>) -> Result<(), TransportError>;
     async fn close(&self);
-    async fn connected(&self);
-    async fn is_connected(&self) -> bool;
+    fn is_connected(&self) -> bool;
 }

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -31,5 +31,13 @@ pub trait Transport {
     async fn receive(&self) -> Result<TransportEvent, TransportError>;
     async fn send(&self, message: Vec<u8>) -> Result<(), TransportError>;
     async fn close(&self);
+
+    fn message_to_transport_event(&self, message: Vec<u8>) -> TransportEvent {
+        match message.len() == 1 && message[0] == 0 && !self.is_connected() {
+            true => TransportEvent::Connect,
+            false => TransportEvent::Message(message),
+        }
+    }
+
     fn is_connected(&self) -> bool;
 }

--- a/src/transports/web_socket.rs
+++ b/src/transports/web_socket.rs
@@ -1,0 +1,122 @@
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    StreamExt, SinkExt, TryStreamExt,
+};
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio_tungstenite::{accept_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+
+use async_trait::async_trait;
+
+use super::{Transport, TransportError, TransportEvent};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Mutex,
+};
+use tokio_tungstenite::connect_async;
+
+type WriteStream =
+    SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tokio_tungstenite::tungstenite::Message>;
+
+type ReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
+
+pub struct WebSocketTransport {
+    read: Mutex<ReadStream>,
+    write: Mutex<WriteStream>,
+    ready: AtomicBool,
+}
+
+impl WebSocketTransport {
+    fn create(ws: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
+        let (write, read) = ws.split();
+        Self {
+            read: Mutex::new(read),
+            write: Mutex::new(write),
+            ready: AtomicBool::new(false),
+        }
+    }
+
+    pub async fn connect(address: &str) -> Result<WebSocketTransport, TransportError> {
+        let (ws, _) = connect_async(address)
+            .await
+            .map_err(|_| TransportError::Connection)?;
+        println!("Connected to {}", address);
+
+        Ok(Self::create(ws))
+    }
+
+    pub async fn listen(address: &str) -> Result<WebSocketTransport, TransportError> {
+        // listen to given address
+        let listener = TcpListener::bind(address).await.expect("Can't listen");
+        println!("Listening on: {}", address);
+
+        // wait for a connection
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                let peer = stream
+                    .peer_addr()
+                    .expect("connected streams should have a peer address");
+                println!("Peer address: {}", peer);
+                let stream = MaybeTlsStream::Plain(stream);
+                let ws = accept_async(stream)
+                    .await
+                    .map_err(|_| TransportError::Internal)?;
+                Ok(Self::create(ws))
+            }
+            _ => Err(TransportError::Connection),
+        }
+    }
+}
+
+#[async_trait]
+impl Transport for WebSocketTransport {
+    async fn receive(&self) -> Result<TransportEvent, TransportError> {
+        while let Ok(next) = self.read.lock().await.try_next().await {
+            match next {
+                Some(message) => {
+                    if message.is_binary() {
+                        let message = message.into_data();
+                        if message.len() == 1 && message[0] == 0 && !self.is_connected() {
+                            self.ready.store(true, Ordering::SeqCst);
+                            return Ok(TransportEvent::Connect);
+                        }
+                        return Ok(TransportEvent::Message(message));
+                    } else {
+                        // Ignore messages that are not binary
+                        return Err(TransportError::Internal);
+                    }
+                }
+                None => {
+                    println!("Nothing yet")
+                }
+            }
+        }
+        self.close().await;
+        Ok(TransportEvent::Close)
+    }
+
+    async fn send(&self, message: Vec<u8>) -> Result<(), TransportError> {
+        let message = Message::binary(message);
+        self.write
+            .lock()
+            .await
+            .send(message)
+            .await
+            .map_err(|_| TransportError::Connection)?;
+        Ok(())
+    }
+
+    async fn close(&self) {
+        match self.write.lock().await.close().await {
+            Ok(_) => {
+                self.ready.store(false, Ordering::SeqCst);
+            }
+            _ => {
+                println!("Couldn't close tranport")
+            }
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.ready.load(Ordering::Relaxed)
+    }
+}

--- a/src/transports/web_socket.rs
+++ b/src/transports/web_socket.rs
@@ -1,13 +1,13 @@
 use futures_util::{
     stream::{SplitSink, SplitStream},
-    StreamExt, SinkExt, TryStreamExt,
+    SinkExt, StreamExt, TryStreamExt,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio_tungstenite::{accept_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
-use async_trait::async_trait;
-
 use super::{Transport, TransportError, TransportEvent};
+use async_trait::async_trait;
+use log::debug;
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::Mutex,
@@ -39,7 +39,7 @@ impl WebSocketTransport {
         let (ws, _) = connect_async(address)
             .await
             .map_err(|_| TransportError::Connection)?;
-        println!("Connected to {}", address);
+        debug!("Connected to {}", address);
 
         Ok(Self::create(ws))
     }
@@ -47,7 +47,7 @@ impl WebSocketTransport {
     pub async fn listen(address: &str) -> Result<WebSocketTransport, TransportError> {
         // listen to given address
         let listener = TcpListener::bind(address).await.expect("Can't listen");
-        println!("Listening on: {}", address);
+        debug!("Listening on: {}", address);
 
         // wait for a connection
         match listener.accept().await {
@@ -55,7 +55,7 @@ impl WebSocketTransport {
                 let peer = stream
                     .peer_addr()
                     .expect("connected streams should have a peer address");
-                println!("Peer address: {}", peer);
+                debug!("Peer address: {}", peer);
                 let stream = MaybeTlsStream::Plain(stream);
                 let ws = accept_async(stream)
                     .await
@@ -86,7 +86,7 @@ impl Transport for WebSocketTransport {
                     }
                 }
                 None => {
-                    println!("Nothing yet")
+                    debug!("Nothing yet")
                 }
             }
         }
@@ -111,7 +111,7 @@ impl Transport for WebSocketTransport {
                 self.ready.store(false, Ordering::SeqCst);
             }
             _ => {
-                println!("Couldn't close tranport")
+                debug!("Couldn't close tranport")
             }
         }
     }


### PR DESCRIPTION
## Description

Adds WebSocket transport implementation, on top of `tokio-tungstenite` crate. It also adds a second run for the integration example, running with both transport implementations.


Closes #8 