### PR TITLE
feat: handle requests concurrently

### DIFF
--- a/examples/integration/src/service/book_service.rs
+++ b/examples/integration/src/service/book_service.rs
@@ -13,13 +13,19 @@ impl BookServiceInterface<MyExampleContext> for BookService {
         assert_eq!(ctx.hardcoded_database.len(), 2);
 
         // Simulate DB operation
-        println!("> BookService > async get_book > simulating DB operation");
-        sleep(Duration::from_secs(1)).await;
+        println!(
+            "> BookService > async get_book {} > simulating DB operation",
+            request.isbn
+        );
+        sleep(Duration::from_secs(2)).await;
         let book = ctx
             .hardcoded_database
             .iter()
             .find(|book_record| book_record.isbn == request.isbn);
-        println!("> BookService > async get_book > awaited DB operation");
+        println!(
+            "> BookService > async get_book {} > simulating DB operation",
+            request.isbn
+        );
 
         book.map(Book::clone).unwrap_or_default()
     }

--- a/examples/integration/src/service/book_service.rs
+++ b/examples/integration/src/service/book_service.rs
@@ -23,7 +23,7 @@ impl BookServiceInterface<MyExampleContext> for BookService {
             .iter()
             .find(|book_record| book_record.isbn == request.isbn);
         println!(
-            "> BookService > async get_book {} > simulating DB operation",
+            "> BookService > async get_book {} > after simulating DB operation",
             request.isbn
         );
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -165,7 +165,12 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
                 payload: procedure_response,
             };
 
-            transport.send(response.encode_to_vec()).await.unwrap();
+            match transport.send(response.encode_to_vec()).await {
+                Ok(_) => {}
+                Err(err) => {
+                    error!("Error while sending the response to request {message_identifier} - error: {err:?}")
+                }
+            }
         });
     }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc, u8};
 
-use log::{error, debug};
+use log::{debug, error};
 use prost::{alloc::vec::Vec, Message};
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
     transports::{Transport, TransportEvent},
     types::{
         ServerModuleDeclaration, ServerModuleProcedures, ServiceModuleDefinition,
-        UnaryRequestHandler,
+        UnaryRequestHandler, UnaryResponse,
     },
 };
 
@@ -40,7 +40,7 @@ pub enum ServerError {
 /// for the port creation.
 pub struct RpcServer<Context> {
     /// The Transport used for the communication between `RpcClient` and `RpcServer`
-    transport: Option<Box<dyn Transport + Send + Sync>>,
+    transport: Option<Arc<dyn Transport + Send + Sync>>,
     /// The handler executed when a new port is created
     handler: Option<Box<PortHandlerFn<Context>>>,
     /// Ports registered in the `RpcServer`
@@ -48,7 +48,7 @@ pub struct RpcServer<Context> {
     /// RpcServer Context
     context: Arc<Context>,
 }
-impl<Context> RpcServer<Context> {
+impl<Context: Send + Sync + 'static> RpcServer<Context> {
     pub fn create(ctx: Context) -> Self {
         Self {
             transport: None,
@@ -60,7 +60,7 @@ impl<Context> RpcServer<Context> {
 
     /// Attach the server half of the transport for Client<>Server comms
     pub fn attach_transport<T: Transport + Send + Sync + 'static>(&mut self, transport: T) {
-        self.transport = Some(Box::new(transport));
+        self.transport = Some(Arc::new(transport));
     }
 
     /// Start listening messages from the attached transport
@@ -129,22 +129,15 @@ impl<Context> RpcServer<Context> {
         match self.ports.get(&request.port_id) {
             Some(port) => {
                 let procedure_ctx = self.context.clone();
-                let procedure_response = port
-                    .call_procedure(request.procedure_id, request.payload, procedure_ctx)
+                let procedure_handler = port
+                    .get_procedure(request.procedure_id, request.payload, procedure_ctx)
                     .await?;
+                let transport = transport.clone();
 
-                let response = Response {
-                    message_identifier: build_message_identifier(
-                        RpcMessageTypes::Response as u32,
-                        message_identifier,
-                    ),
-                    payload: procedure_response,
-                };
+                tokio::spawn(async move {
+                    handle_request(transport, message_identifier, procedure_handler).await
+                });
 
-                transport
-                    .send(response.encode_to_vec())
-                    .await
-                    .map_err(|_| ServerError::TransportError)?;
                 Ok(())
             }
             _ => Err(ServerError::PortNotFound),
@@ -185,7 +178,7 @@ impl<Context> RpcServer<Context> {
                         RpcMessageTypes::RequestModuleResponse as u32,
                         message_identifier,
                     ),
-                    procedures
+                    procedures,
                 };
                 let response = response.encode_to_vec();
                 transport
@@ -375,16 +368,33 @@ impl<Context> RpcServerPort<Context> {
         }
     }
 
-    /// It will look up the procedure id in the port's `procedures` and execute the procedure's handler
-    async fn call_procedure(
+    /// It will look up the procedure id in the port's `procedures` and return the procedure's handler
+    async fn get_procedure(
         &self,
         procedure_id: u32,
         payload: Vec<u8>,
         context: Arc<Context>,
-    ) -> ServerResult<Vec<u8>> {
+    ) -> ServerResult<UnaryResponse> {
         match self.procedures.get(&procedure_id) {
-            Some(procedure_handler) => Ok(procedure_handler(payload, context).await),
+            Some(procedure_handler) => Ok(procedure_handler(payload, context)),
             _ => Err(ServerError::ProcedureError),
         }
     }
+}
+
+async fn handle_request(
+    transport: Arc<dyn Transport + Send + Sync>,
+    message_identifier: u32,
+    request_handler: UnaryResponse,
+) {
+    let procedure_response = request_handler.await;
+    let response = Response {
+        message_identifier: build_message_identifier(
+            RpcMessageTypes::Response as u32,
+            message_identifier,
+        ),
+        payload: procedure_response,
+    };
+
+    transport.send(response.encode_to_vec()).await.unwrap();
 }

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -144,8 +144,9 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
         }
     }
 
-    /// Receive a procedure handler future and process it
+    /// Receive a procedure handler future and process it.
     ///
+    /// This function aims to run the procedure handler in another task to achieve processing requests concurrently.
     /// # Arguments
     ///
     /// * `transport` - Cloned transport from `RpcServer`

--- a/rpc/src/types/mod.rs
+++ b/rpc/src/types/mod.rs
@@ -1,8 +1,10 @@
 use core::future::Future;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
+pub type UnaryResponse = Pin<Box<dyn Future<Output = Vec<u8>> + Send>>;
+
 pub type UnaryRequestHandler<Context> =
-    dyn Fn(Vec<u8>, Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>> + Send + Sync;
+    dyn Fn(Vec<u8>, Arc<Context>) -> UnaryResponse + Send + Sync;
 
 pub struct ServiceModuleDefinition<Context> {
     definitions: HashMap<String, Arc<UnaryRequestHandler<Context>>>,


### PR DESCRIPTION
This PR: 
- spawn a task for each `Request` message to be able to process requests concurrently

### Example with this branch
#### Before
- `just run-integration` output previous to the feat:
```bash
> Concurrent Example <
> BookService > async get_book 1000 > simulating DB operation // _(req = 1)_  
> BookService > async get_book 1000 > after simulating DB operation // _(req = 1)_  
> Service Definition > Get Book > response: Book { isbn: 1000, title: "Rust: crash course", author: "mr steve" }
> BookService > async get_book 1010 > simulating DB operation // _(req = 2)_  
> BookService > async get_book 1010 > after simulating DB operation // _(req = 2)_  
> Service Definition > Get Book > response: Book { isbn: 1010, title: "Rust: how do futures work under the hood?", author: "mr jobs" }
```

#### After
- `just run-integration` output after the feat:
```bash
> Concurrent Example <
> BookService > async get_book 1010 > simulating DB operation // _(req = 1)_  
> BookService > async get_book 1000 > simulating DB operation // _(req = 2)_  
> BookService > async get_book 1010 > after simulating DB operation // _(req = 1)_  
> Service Definition > Get Book > response: Book { isbn: 1010, title: "Rust: how do futures work under the hood?", author: "mr jobs" }
> BookService > async get_book 1000 > after simulating DB operation // _(req = 2)_  
> Service Definition > Get Book > response: Book { isbn: 1000, title: "Rust: crash course", author: "mr steve" }
```