### PR TITLE
feat: add server streams procedures

### DIFF
--- a/examples/integration/src/codegen/client.rs
+++ b/examples/integration/src/codegen/client.rs
@@ -1,11 +1,15 @@
 // THIS CODE SHOULD BE AUTO-GENERATED
-use rpc_rust::client::{RpcClientModule, ServiceClient};
+use rpc_rust::{
+    client::{RpcClientModule, ServiceClient},
+    stream_protocol::Stream,
+};
 
-use crate::{Book, GetBookRequest};
+use crate::{Book, GetBookRequest, QueryBooksRequest};
 
 #[async_trait::async_trait]
 pub trait BookServiceClientInterface {
     async fn get_book(&self, payload: GetBookRequest) -> Book;
+    async fn query_books(&self, payload: QueryBooksRequest) -> Stream<Book>;
 }
 
 pub struct BookServiceClient {
@@ -23,6 +27,12 @@ impl BookServiceClientInterface for BookServiceClient {
     async fn get_book(&self, payload: GetBookRequest) -> Book {
         self.rpc_client_module
             .call_unary_procedure("GetBook", payload)
+            .await
+            .unwrap()
+    }
+    async fn query_books(&self, payload: QueryBooksRequest) -> Stream<Book> {
+        self.rpc_client_module
+            .call_server_streams_procedure("QueryBooks", payload)
             .await
             .unwrap()
     }

--- a/examples/integration/src/codegen/mod.rs
+++ b/examples/integration/src/codegen/mod.rs
@@ -1,2 +1,6 @@
+use tokio::sync::mpsc::UnboundedReceiver;
+
 pub mod client;
 pub mod server;
+
+pub type ServerStreamResponse<T> = UnboundedReceiver<T>;

--- a/examples/integration/src/codegen/server.rs
+++ b/examples/integration/src/codegen/server.rs
@@ -34,27 +34,27 @@ impl BookServiceCodeGen {
         println!("> BookServiceCodeGen > register_service");
         let mut service_def = ServiceModuleDefinition::new();
         // Share service ownership
-        let sharable_service = Arc::new(service);
+        let shareable_service = Arc::new(service);
         // Clone it for "GetBook" procedure
-        let service = Arc::clone(&sharable_service);
+        let service = Arc::clone(&shareable_service);
         service_def.add_unary("GetBook", move |request, context| {
-            let serv = service.clone();
+            let service = service.clone();
             Box::pin(async move {
-                let res = serv
+                let response = service
                     .get_book(GetBookRequest::decode(request.as_slice()).unwrap(), context)
                     .await;
-                println!("> Service Definition > Get Book > response: {:?}", res);
-                res.encode_to_vec()
+                println!("> Service Definition > Get Book > response: {:?}", response);
+                response.encode_to_vec()
             })
         });
 
-        let service = Arc::clone(&sharable_service);
+        let service = Arc::clone(&shareable_service);
         service_def.add_server_streams("QueryBooks", move |request, context| {
-            let serv = service.clone();
+            let service = service.clone();
             Box::pin(async move {
                 let (tx, rx): (UnboundedSender<Vec<u8>>, UnboundedReceiver<Vec<u8>>) =
                     unbounded_channel();
-                let mut server_stream = serv
+                let mut server_stream = service
                     .query_books(
                         QueryBooksRequest::decode(request.as_slice()).unwrap(),
                         context,

--- a/examples/integration/src/codegen/server.rs
+++ b/examples/integration/src/codegen/server.rs
@@ -3,14 +3,22 @@ use std::sync::Arc;
 
 use prost::Message;
 use rpc_rust::{server::RpcServerPort, types::ServiceModuleDefinition};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-use crate::{Book, GetBookRequest};
+use crate::{Book, GetBookRequest, QueryBooksRequest};
+
+use super::ServerStreamResponse;
 
 pub const SERVICE: &str = "BookService";
 
 #[async_trait::async_trait]
 pub trait BookServiceInterface<Context> {
     async fn get_book(&self, request: GetBookRequest, context: Arc<Context>) -> Book;
+    async fn query_books(
+        &self,
+        request: QueryBooksRequest,
+        context: Arc<Context>,
+    ) -> ServerStreamResponse<Book>;
 }
 
 pub struct BookServiceCodeGen {}
@@ -29,7 +37,7 @@ impl BookServiceCodeGen {
         let service = Arc::new(service);
         // Clone it for "GetBook" procedure
         let serv = Arc::clone(&service);
-        service_def.add_definition("GetBook".to_string(), move |request, context| {
+        service_def.add_unary("GetBook", move |request, context| {
             let serv = serv.clone();
             Box::pin(async move {
                 let res = serv
@@ -37,6 +45,29 @@ impl BookServiceCodeGen {
                     .await;
                 println!("> Service Definition > Get Book > response: {:?}", res);
                 res.encode_to_vec()
+            })
+        });
+
+        let serv = Arc::clone(&service);
+        service_def.add_server_streams("QueryBooks", move |request, context| {
+            let serv = serv.clone();
+            Box::pin(async move {
+                let (tx, rx): (UnboundedSender<Vec<u8>>, UnboundedReceiver<Vec<u8>>) =
+                    unbounded_channel();
+                let mut res = serv
+                    .query_books(
+                        QueryBooksRequest::decode(request.as_slice()).unwrap(),
+                        context,
+                    )
+                    .await;
+
+                tokio::spawn(async move {
+                    while let Some(book) = res.recv().await {
+                        tx.send(book.encode_to_vec()).unwrap();
+                    }
+                });
+
+                rx
             })
         });
         port.register_module(SERVICE.to_string(), service_def)

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -168,9 +168,9 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
             author_prefix: "mr".to_string(),
         };
 
-        let mut response = book_service_module.query_books(query_books_payload).await;
+        let mut response_stream = book_service_module.query_books(query_books_payload).await;
 
-        while let Some(book) = response.next().await {
+        while let Some(book) = response_stream.next().await {
             println!("> Server Streams > QueryBooks > Book {:?}", book)
         }
     });

--- a/examples/integration/src/service/api.proto
+++ b/examples/integration/src/service/api.proto
@@ -16,4 +16,5 @@ message QueryBooksRequest {
 
 service BookService {
   rpc GetBook(GetBookRequest) returns (Book) {}
+  rpc QueryBooks(QueryBooksRequest) returns (stream Book) {}
 }

--- a/examples/integration/src/service/book_service.rs
+++ b/examples/integration/src/service/book_service.rs
@@ -1,7 +1,12 @@
-use crate::{Book, GetBookRequest, MyExampleContext};
+use crate::{
+    codegen::ServerStreamResponse, Book, GetBookRequest, MyExampleContext, QueryBooksRequest,
+};
 use std::{sync::Arc, time::Duration};
 
-use tokio::time::sleep;
+use tokio::{
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    time::sleep,
+};
 
 use crate::codegen::server::BookServiceInterface;
 
@@ -10,7 +15,7 @@ pub struct BookService {}
 #[async_trait::async_trait]
 impl BookServiceInterface<MyExampleContext> for BookService {
     async fn get_book(&self, request: GetBookRequest, ctx: Arc<MyExampleContext>) -> Book {
-        assert_eq!(ctx.hardcoded_database.len(), 2);
+        assert_eq!(ctx.hardcoded_database.len(), 5);
 
         // Simulate DB operation
         println!(
@@ -28,5 +33,25 @@ impl BookServiceInterface<MyExampleContext> for BookService {
         );
 
         book.map(Book::clone).unwrap_or_default()
+    }
+
+    async fn query_books(
+        &self,
+        request: QueryBooksRequest,
+        ctx: Arc<MyExampleContext>,
+    ) -> ServerStreamResponse<Book> {
+        println!("> BookService > server stream > QueryBooks");
+        let (tx, rx): (UnboundedSender<Book>, UnboundedReceiver<Book>) = unbounded_channel();
+        // Spawn for a quick response
+        tokio::spawn(async move {
+            for book in &ctx.hardcoded_database {
+                sleep(Duration::from_secs(1)).await;
+                if book.author.contains(&request.author_prefix) {
+                    tx.send(book.clone()).unwrap();
+                }
+            }
+        });
+
+        rx
     }
 }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -306,7 +306,13 @@ impl ClientRequestDispatcher {
             .register_listener(message_id, listener)
             .await;
 
-        stream_protocol.start_processing();
+        let client_messages_handler_listener_removal = self.client_messages_handler.clone();
+        stream_protocol.start_processing(move || async move {
+            // Callback for remove listener
+            client_messages_handler_listener_removal
+                .unregister_listener(message_id)
+                .await;
+        });
 
         Stream(stream_protocol)
     }

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -196,7 +196,7 @@ impl RpcClientModule {
             .stream_server_messages(self.port_id, response.1)
             .await;
 
-        if let Err(_) = stream_protocol.acknowledge_open().await {
+        if (stream_protocol.acknowledge_open().await).is_err() {
             return Err(ClientError::TransportError);
         }
 
@@ -268,7 +268,7 @@ impl ClientRequestDispatcher {
             // store next_message_id
             *message_lock += 1;
             (payload, message_id)
-        }; // Force to drop the mutex for other conccurrent operations
+        }; // Force to drop the mutex for other concurrent operations
 
         let payload = payload.encode_to_vec();
         self.messages_handler

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod client;
+pub mod messages_handlers;
 pub mod protocol;
 pub mod server;
+pub mod stream_protocol;
 pub mod transports;
 pub mod types;

--- a/rpc/src/messages_handlers.rs
+++ b/rpc/src/messages_handlers.rs
@@ -345,4 +345,9 @@ impl ClientMessagesHandler {
         let mut lock = self.listeners.lock().await;
         lock.insert(message_id, callback);
     }
+
+    pub async fn unregister_listener(&self, message_id: u32) {
+        let mut lock = self.listeners.lock().await;
+        lock.remove(&message_id);
+    }
 }

--- a/rpc/src/messages_handlers.rs
+++ b/rpc/src/messages_handlers.rs
@@ -1,0 +1,348 @@
+use std::{collections::HashMap, sync::Arc};
+
+use log::{debug, error};
+use prost::Message;
+use tokio::{
+    select,
+    sync::{
+        mpsc::UnboundedReceiver,
+        oneshot::{
+            channel as oneshot_channel, Receiver as OneShotReceiver, Sender as OneShotSender,
+        },
+        Mutex,
+    },
+};
+
+use async_channel::Sender as AsyncChannelSender;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    protocol::{
+        parse::{
+            build_message_identifier, parse_header, parse_message_identifier,
+            parse_protocol_message,
+        },
+        Response, RpcMessageTypes, StreamMessage,
+    },
+    server::{ServerError, ServerResult},
+    transports::{Transport, TransportEvent},
+    types::{ServerStreamsResponse, UnaryResponse},
+};
+
+pub struct ServerMessagesHandler {
+    ack_listeners: Mutex<HashMap<String, OneShotSender<Vec<u8>>>>,
+}
+
+impl ServerMessagesHandler {
+    pub fn new() -> Self {
+        Self {
+            ack_listeners: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Receive a procedure handler future and process it in another task.
+    ///
+    /// This function aims to run the procedure handler in another task to achieve processing requests concurrently.
+    /// # Arguments
+    ///
+    /// * `transport` - Cloned transport from `RpcServer`
+    /// * `message_idenifier` - Message id to be sent in the response
+    /// * `request_handler` - Procedure handler future to be executed
+    pub fn process_unary_request(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message_identifier: u32,
+        procedure_handler: UnaryResponse,
+    ) {
+        tokio::spawn(async move {
+            let procedure_response = procedure_handler.await;
+            let response = Response {
+                message_identifier: build_message_identifier(
+                    RpcMessageTypes::Response as u32,
+                    message_identifier,
+                ),
+                payload: procedure_response,
+            };
+
+            transport.send(response.encode_to_vec()).await.unwrap();
+        });
+    }
+
+    pub fn process_server_streams_request(
+        self: Arc<Self>,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message_identifier: u32,
+        port_id: u32,
+        procedure_handler: ServerStreamsResponse,
+    ) {
+        tokio::spawn(async move {
+            let open_ack_listener = self
+                .open_server_stream(transport.clone(), message_identifier, port_id)
+                .await
+                .unwrap();
+
+            open_ack_listener.await.unwrap();
+
+            let stream = procedure_handler.await;
+
+            self.send_server_stream_through_transport(
+                transport,
+                stream,
+                port_id,
+                message_identifier,
+            )
+            .await
+            .unwrap()
+        });
+    }
+
+    async fn open_server_stream(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message_identifier: u32,
+        port_id: u32,
+    ) -> ServerResult<OneShotReceiver<Vec<u8>>> {
+        let opening_message = StreamMessage {
+            closed: false,
+            ack: false,
+            sequence_id: 0,
+            message_identifier: build_message_identifier(
+                RpcMessageTypes::StreamMessage as u32,
+                message_identifier,
+            ),
+            port_id,
+            payload: vec![],
+        };
+
+        self.send_stream(transport, opening_message).await
+    }
+
+    async fn close_server_stream(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        sequence_id: u32,
+        message_identifier: u32,
+        port_id: u32,
+    ) -> ServerResult<()> {
+        let close_message = StreamMessage {
+            closed: true,
+            ack: false,
+            sequence_id,
+            message_identifier: build_message_identifier(
+                RpcMessageTypes::StreamMessage as u32,
+                message_identifier,
+            ),
+            port_id,
+            payload: vec![],
+        };
+
+        transport.send(close_message.encode_to_vec()).await.unwrap();
+
+        Ok(())
+    }
+
+    async fn send_server_stream_through_transport(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        mut stream: UnboundedReceiver<Vec<u8>>,
+        port_id: u32,
+        message_identifier: u32,
+    ) -> ServerResult<()> {
+        let mut sequence_number = 0;
+
+        while let Some(message) = stream.recv().await {
+            sequence_number += 1;
+            let current_message = StreamMessage {
+                closed: false,
+                ack: false,
+                sequence_id: sequence_number,
+                message_identifier: build_message_identifier(
+                    RpcMessageTypes::StreamMessage as u32,
+                    message_identifier,
+                ),
+                port_id,
+                payload: message,
+            };
+            let transport_cloned = transport.clone();
+
+            match self.send_stream(transport_cloned, current_message).await {
+                Ok(listener) => {
+                    let ack_message = match listener.await {
+                        Ok(msg) => match StreamMessage::decode(msg.as_slice()) {
+                            Ok(msg) => msg,
+                            Err(_) => break,
+                        },
+                        Err(_) => break,
+                    };
+                    if ack_message.ack {
+                        continue;
+                    } else if ack_message.closed {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    error!("Error while streaming a server stream {err:?}");
+                    break;
+                }
+            }
+        }
+
+        self.close_server_stream(transport, sequence_number, message_identifier, port_id)
+            .await
+            .unwrap();
+
+        Ok(())
+    }
+
+    async fn send_stream(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message: StreamMessage,
+    ) -> ServerResult<OneShotReceiver<Vec<u8>>> {
+        let (_, message_id) = parse_message_identifier(message.message_identifier);
+        let (tx, rx) = oneshot_channel();
+        {
+            let mut lock = self.ack_listeners.lock().await;
+            lock.insert(format!("{}{}", message_id, message.sequence_id), tx);
+        }
+
+        transport
+            .send(message.encode_to_vec())
+            .await
+            .map_err(|_| ServerError::TransportError)?;
+
+        Ok(rx)
+    }
+
+    pub fn acknowledge_message(self: Arc<Self>, message_identifier: u32, payload: Vec<u8>) {
+        tokio::spawn(async move {
+            let stream_message = parse_protocol_message::<StreamMessage>(&payload).unwrap().2;
+            let listener = {
+                let mut lock = self.ack_listeners.lock().await;
+                // we should remove ack listener it just for a seq_id
+                lock.remove(&format!(
+                    "{}{}",
+                    message_identifier, stream_message.sequence_id
+                ))
+            };
+            match listener {
+                Some(sender) => sender.send(payload).unwrap(),
+                None => {
+                    debug!("> RpcServer > ack listener not found")
+                }
+            }
+        });
+    }
+}
+
+pub struct ClientMessagesHandler {
+    pub transport: Arc<dyn Transport + Send + Sync>,
+    one_time_listeners: Mutex<HashMap<u32, OneShotSender<Vec<u8>>>>,
+    listeners: Mutex<HashMap<u32, AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>>>,
+    process_cancellation_token: CancellationToken,
+}
+
+impl ClientMessagesHandler {
+    pub fn new(transport: Arc<dyn Transport + Send + Sync>) -> Self {
+        Self {
+            transport,
+            one_time_listeners: Mutex::new(HashMap::new()),
+            process_cancellation_token: CancellationToken::new(),
+            listeners: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn start(self: Arc<Self>) {
+        let token = self.process_cancellation_token.clone();
+        tokio::spawn(async move {
+            select! {
+                _ = token.cancelled() => {
+                    debug!("> ClientRequestDispatcher cancelled!")
+                },
+                _ = self.process() => {
+
+                }
+            }
+        });
+    }
+
+    pub fn stop(&self) {
+        self.process_cancellation_token.cancel();
+    }
+
+    async fn process(&self) {
+        loop {
+            match self.transport.receive().await {
+                Ok(TransportEvent::Message(data)) => {
+                    let message_header = parse_header(&data);
+                    // TODO: find a way to communicate the error of parsing the message_header
+                    match message_header {
+                        Some(message_header) => {
+                            let mut read_callbacks = self.one_time_listeners.lock().await;
+                            // We remove the listener in order to get a owned value and also remove it from memory
+                            let sender = read_callbacks.remove(&message_header.1);
+                            if let Some(sender) = sender {
+                                match sender.send(data) {
+                                    Ok(()) => {}
+                                    Err(_) => {
+                                        debug!(
+                                            "> Client > error while sending {} response",
+                                            message_header.1
+                                        );
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                let listeners = self.listeners.lock().await;
+                                let listener = listeners.get(&message_header.1);
+                                if let Some(listener) = listener {
+                                    match listener
+                                        .send((
+                                            message_header.0,
+                                            message_header.1,
+                                            StreamMessage::decode(data.as_slice()).unwrap(),
+                                        ))
+                                        .await
+                                    {
+                                        Ok(_) => {}
+                                        Err(_) => {}
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            debug!("> Client > Error on parsing message header");
+                            continue;
+                        }
+                    }
+                }
+                Ok(_) => {
+                    // Ignore another type of TransportEvent
+                    continue;
+                }
+                Err(_) => {
+                    error!("Client error on receiving");
+                    break;
+                }
+            }
+        }
+    }
+
+    pub async fn register_one_time_listener(
+        &self,
+        message_id: u32,
+        callback: OneShotSender<Vec<u8>>,
+    ) {
+        let mut lock = self.one_time_listeners.lock().await;
+        lock.insert(message_id, callback);
+    }
+
+    pub async fn register_listener(
+        &self,
+        message_id: u32,
+        callback: AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>,
+    ) {
+        let mut lock = self.listeners.lock().await;
+        lock.insert(message_id, callback);
+    }
+}

--- a/rpc/src/stream_protocol.rs
+++ b/rpc/src/stream_protocol.rs
@@ -1,0 +1,157 @@
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use log::debug;
+use prost::Message;
+
+use async_channel::{
+    unbounded as async_unbounded, Receiver as AsyncChannelReceiver, Sender as AsyncChannelSender,
+};
+use tokio::select;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    protocol::{parse::build_message_identifier, RpcMessageTypes, StreamMessage},
+    transports::{Transport, TransportError},
+};
+
+pub struct Stream<M: Message + Default>(pub StreamProtocol<M>);
+
+impl<M: Message + Default> Deref for Stream<M> {
+    type Target = StreamProtocol<M>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<M: Message + Default> DerefMut for Stream<M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct StreamProtocol<M: Message + Default> {
+    port_id: u32,
+    message_number: u32,
+    last_received_sequence_id: u32,
+    is_remote_closed: bool,
+    was_open: bool,
+    channel: (AsyncChannelSender<M>, AsyncChannelReceiver<M>),
+    transport: Arc<dyn Transport + Send + Sync>,
+    messages_processor: AsyncChannelReceiver<(RpcMessageTypes, u32, StreamMessage)>,
+    process_cancellation_token: CancellationToken,
+}
+
+impl<M: Message + Default + 'static> StreamProtocol<M> {
+    pub(crate) fn create(
+        transport: Arc<dyn Transport + Send + Sync>,
+        port_id: u32,
+        message_number: u32,
+    ) -> (
+        Self,
+        AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>,
+    ) {
+        let (tx, rx) = async_unbounded();
+
+        (
+            Self {
+                last_received_sequence_id: 0,
+                is_remote_closed: false,
+                was_open: false,
+                channel: async_unbounded(),
+                transport,
+                message_number,
+                port_id,
+                messages_processor: rx,
+                process_cancellation_token: CancellationToken::new(),
+            },
+            tx,
+        )
+    }
+
+    pub async fn next(&mut self) -> Option<M> {
+        match self.channel.1.recv().await {
+            Ok(msg) => {
+                self.last_received_sequence_id += 1;
+                self.was_open = true;
+                let stream_message = StreamMessage {
+                    port_id: self.port_id,
+                    sequence_id: self.last_received_sequence_id,
+                    message_identifier: build_message_identifier(
+                        RpcMessageTypes::StreamAck as u32,
+                        self.message_number,
+                    ),
+                    payload: vec![],
+                    closed: false,
+                    ack: true,
+                };
+
+                self.transport
+                    .send(stream_message.encode_to_vec())
+                    .await
+                    .unwrap();
+
+                Some(msg)
+            }
+            Err(_) => {
+                self.is_remote_closed = true;
+                None
+            }
+        }
+    }
+
+    pub(crate) async fn acknowledge_open(&self) -> Result<(), TransportError> {
+        let stream_message = StreamMessage {
+            port_id: self.port_id,
+            sequence_id: self.last_received_sequence_id,
+            message_identifier: build_message_identifier(
+                RpcMessageTypes::StreamAck as u32,
+                self.message_number,
+            ),
+            payload: vec![],
+            closed: false,
+            ack: true,
+        };
+
+        self.transport.send(stream_message.encode_to_vec()).await
+    }
+
+    pub fn close(&self) {
+        self.channel.1.close();
+        self.process_cancellation_token.cancel();
+    }
+
+    pub fn start_processing(&self) {
+        let token = self.process_cancellation_token.clone();
+        let messages_processor = self.messages_processor.clone();
+        let internal_channel = (self.channel.0.clone(), self.channel.1.clone());
+        tokio::spawn(async move {
+            select! {
+                _ = token.cancelled() => {
+                    debug!("> StreamProtocol cancelled!")
+                },
+                _ = Self::process_messages(messages_processor, internal_channel) => {
+
+                }
+            }
+        });
+    }
+
+    async fn process_messages(
+        messages_processor: AsyncChannelReceiver<(RpcMessageTypes, u32, StreamMessage)>,
+        internal_channel: (AsyncChannelSender<M>, AsyncChannelReceiver<M>),
+    ) {
+        while let Ok(message) = messages_processor.recv().await {
+            if matches!(message.0, RpcMessageTypes::StreamMessage) {
+                if message.2.closed {
+                    internal_channel.1.close();
+                } else {
+                    let decoded = M::decode(message.2.payload.as_slice()).unwrap();
+                    internal_channel.0.send(decoded).await.unwrap();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR:
- add server streams procedures
- add handlers for messages to `RpcServer` and `RpcClient` for orderliness
- add server streams procedure to the example

Closes #11 