### PR TITLE
feat: add client streams procedures

### DIFF
--- a/examples/integration/src/codegen/client.rs
+++ b/examples/integration/src/codegen/client.rs
@@ -1,15 +1,18 @@
 // THIS CODE SHOULD BE AUTO-GENERATED
 use rpc_rust::{
     client::{RpcClientModule, ServiceClient},
-    stream_protocol::Stream,
+    stream_protocol::Generator,
 };
 
 use crate::{Book, GetBookRequest, QueryBooksRequest};
 
+use super::ClientStreamRequest;
+
 #[async_trait::async_trait]
 pub trait BookServiceClientInterface {
     async fn get_book(&self, payload: GetBookRequest) -> Book;
-    async fn query_books(&self, payload: QueryBooksRequest) -> Stream<Book>;
+    async fn query_books(&self, payload: QueryBooksRequest) -> Generator<Book>;
+    async fn get_book_stream(&self, payload: ClientStreamRequest<GetBookRequest>) -> Book;
 }
 
 pub struct BookServiceClient {
@@ -30,9 +33,15 @@ impl BookServiceClientInterface for BookServiceClient {
             .await
             .unwrap()
     }
-    async fn query_books(&self, payload: QueryBooksRequest) -> Stream<Book> {
+    async fn query_books(&self, payload: QueryBooksRequest) -> Generator<Book> {
         self.rpc_client_module
             .call_server_streams_procedure("QueryBooks", payload)
+            .await
+            .unwrap()
+    }
+    async fn get_book_stream(&self, payload: ClientStreamRequest<GetBookRequest>) -> Book {
+        self.rpc_client_module
+            .call_client_streams_procedure("GetBookStream", payload)
             .await
             .unwrap()
     }

--- a/examples/integration/src/codegen/mod.rs
+++ b/examples/integration/src/codegen/mod.rs
@@ -1,6 +1,7 @@
-use tokio::sync::mpsc::UnboundedReceiver;
+use rpc_rust::stream_protocol::Generator;
 
 pub mod client;
 pub mod server;
 
-pub type ServerStreamResponse<T> = UnboundedReceiver<T>;
+pub type ServerStreamResponse<T> = Generator<T>;
+pub type ClientStreamRequest<T> = Generator<T>;

--- a/examples/integration/src/codegen/server.rs
+++ b/examples/integration/src/codegen/server.rs
@@ -70,6 +70,7 @@ impl BookServiceCodeGen {
                 rx
             })
         });
+
         port.register_module(SERVICE.to_string(), service_def)
     }
 }

--- a/examples/integration/src/codegen/server.rs
+++ b/examples/integration/src/codegen/server.rs
@@ -56,7 +56,7 @@ impl BookServiceCodeGen {
         service_def.add_server_streams("QueryBooks", move |request, context| {
             let service = service.clone();
             Box::pin(async move {
-                let server_streams = serv
+                let server_streams = service
                     .query_books(
                         QueryBooksRequest::decode(request.as_slice()).unwrap(),
                         context,
@@ -71,7 +71,7 @@ impl BookServiceCodeGen {
             })
         });
 
-        let serv = Arc::clone(&service);
+        let serv = Arc::clone(&shareable_service);
         service_def.add_client_streams("GetBookStream", move |request, context| {
             let serv = serv.clone();
             Box::pin(async move {

--- a/examples/integration/src/codegen/server.rs
+++ b/examples/integration/src/codegen/server.rs
@@ -64,10 +64,7 @@ impl BookServiceCodeGen {
                     .await;
 
                 // Transforming and filling the new generator is spawned so the response it quick
-                let new_generator =
-                    Generator::from_generator(server_streams, |item| item.encode_to_vec());
-
-                new_generator
+                Generator::from_generator(server_streams, |item| item.encode_to_vec())
             })
         });
 

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -171,7 +171,7 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
 
         let mut response_stream = book_service_module.query_books(query_books_payload).await;
 
-        while let Some(book) = response.next().await {
+        while let Some(book) = response_stream.next().await {
             println!(
                 "> Book Service > Server Streams > QueryBooks > Response {:?}",
                 book
@@ -182,6 +182,7 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
         let (generator, generator_yielder) = Generator::create();
         tokio::spawn(async move {
             for _ in 0..4 {
+                println!("> Book Service > Client Stream > Sending stream payload");
                 generator_yielder
                     .insert(GetBookRequest { isbn: 1000 })
                     .await

--- a/examples/integration/src/service/api.proto
+++ b/examples/integration/src/service/api.proto
@@ -17,4 +17,5 @@ message QueryBooksRequest {
 service BookService {
   rpc GetBook(GetBookRequest) returns (Book) {}
   rpc QueryBooks(QueryBooksRequest) returns (stream Book) {}
+  rpc GetBookStream(stream GetBookRequest) returns (Book) {}
 }

--- a/examples/integration/src/service/book_service.rs
+++ b/examples/integration/src/service/book_service.rs
@@ -59,7 +59,7 @@ impl BookServiceInterface<MyExampleContext> for BookService {
         mut request: ClientStreamRequest<GetBookRequest>,
         ctx: Arc<MyExampleContext>,
     ) -> Book {
-        while let Some(_) = request.next().await {}
+        while request.next().await.is_some() {}
 
         ctx.hardcoded_database[0].clone()
     }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -5,3 +5,9 @@ pub mod server;
 pub mod stream_protocol;
 pub mod transports;
 pub mod types;
+
+pub enum CommonError {
+    ProtocolError,
+    TransportError,
+    TransportNotAttached,
+}

--- a/rpc/src/messages_handlers.rs
+++ b/rpc/src/messages_handlers.rs
@@ -5,7 +5,6 @@ use prost::Message;
 use tokio::{
     select,
     sync::{
-        mpsc::UnboundedReceiver,
         oneshot::{
             channel as oneshot_channel, Receiver as OneShotReceiver, Sender as OneShotSender,
         },
@@ -25,19 +24,22 @@ use crate::{
         Response, RpcMessageTypes, StreamMessage,
     },
     server::{ServerError, ServerResult},
+    stream_protocol::Generator,
     transports::{Transport, TransportEvent},
-    types::{ServerStreamsResponse, UnaryResponse},
+    types::{ClientStreamsResponse, ServerStreamsResponse, UnaryResponse},
 };
 
 #[derive(Default)]
 pub struct ServerMessagesHandler {
-    ack_listeners: Mutex<HashMap<String, OneShotSender<Vec<u8>>>>,
+    pub streams_handler: Arc<StreamsHandler>,
+    listeners: Mutex<HashMap<u32, AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>>>,
 }
 
 impl ServerMessagesHandler {
     pub fn new() -> Self {
         Self {
-            ack_listeners: Mutex::new(HashMap::new()),
+            streams_handler: Arc::new(StreamsHandler::new()),
+            listeners: Mutex::new(HashMap::new()),
         }
     }
 
@@ -86,15 +88,61 @@ impl ServerMessagesHandler {
 
             let stream = procedure_handler.await;
 
-            self.send_server_stream_through_transport(
-                transport,
-                stream,
-                port_id,
-                message_identifier,
-            )
-            .await
-            .unwrap()
+            self.streams_handler
+                .send_stream_through_transport(transport, stream, port_id, message_identifier)
+                .await
+                .unwrap()
         });
+    }
+
+    pub fn process_client_streams_request(
+        self: Arc<Self>,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message_identifier: u32,
+        client_stream_id: u32,
+        procedure_handler: ClientStreamsResponse,
+        listener: AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>,
+    ) {
+        tokio::spawn(async move {
+            self.register_listener(client_stream_id, listener).await;
+            let response = procedure_handler.await;
+            self.send_response(transport, message_identifier, response)
+                .await;
+        });
+    }
+
+    pub fn notify_new_client_stream(self: Arc<Self>, message_identifier: u32, payload: Vec<u8>) {
+        tokio::spawn(async move {
+            let lock = self.listeners.lock().await;
+            let listener = lock.get(&message_identifier);
+            if let Some(listener) = listener {
+                listener
+                    .send((
+                        RpcMessageTypes::StreamMessage,
+                        message_identifier,
+                        StreamMessage::decode(payload.as_slice()).unwrap(),
+                    ))
+                    .await
+                    .unwrap()
+            }
+        });
+    }
+
+    pub async fn send_response(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message_identifier: u32,
+        payload: Vec<u8>,
+    ) {
+        let response = Response {
+            message_identifier: build_message_identifier(
+                RpcMessageTypes::Response as u32,
+                message_identifier,
+            ),
+            payload,
+        };
+
+        transport.send(response.encode_to_vec()).await.unwrap();
     }
 
     async fn open_server_stream(
@@ -115,124 +163,23 @@ impl ServerMessagesHandler {
             payload: vec![],
         };
 
-        self.send_stream(transport, opening_message).await
-    }
-
-    async fn close_server_stream(
-        &self,
-        transport: Arc<dyn Transport + Send + Sync>,
-        sequence_id: u32,
-        message_identifier: u32,
-        port_id: u32,
-    ) -> ServerResult<()> {
-        let close_message = StreamMessage {
-            closed: true,
-            ack: false,
-            sequence_id,
-            message_identifier: build_message_identifier(
-                RpcMessageTypes::StreamMessage as u32,
-                message_identifier,
-            ),
-            port_id,
-            payload: vec![],
-        };
-
-        transport.send(close_message.encode_to_vec()).await.unwrap();
-
-        Ok(())
-    }
-
-    async fn send_server_stream_through_transport(
-        &self,
-        transport: Arc<dyn Transport + Send + Sync>,
-        mut stream: UnboundedReceiver<Vec<u8>>,
-        port_id: u32,
-        message_identifier: u32,
-    ) -> ServerResult<()> {
-        let mut sequence_number = 0;
-
-        while let Some(message) = stream.recv().await {
-            sequence_number += 1;
-            let current_message = StreamMessage {
-                closed: false,
-                ack: false,
-                sequence_id: sequence_number,
-                message_identifier: build_message_identifier(
-                    RpcMessageTypes::StreamMessage as u32,
-                    message_identifier,
-                ),
-                port_id,
-                payload: message,
-            };
-            let transport_cloned = transport.clone();
-
-            match self.send_stream(transport_cloned, current_message).await {
-                Ok(listener) => {
-                    let ack_message = match listener.await {
-                        Ok(msg) => match StreamMessage::decode(msg.as_slice()) {
-                            Ok(msg) => msg,
-                            Err(_) => break,
-                        },
-                        Err(_) => break,
-                    };
-                    if ack_message.ack {
-                        continue;
-                    } else if ack_message.closed {
-                        break;
-                    }
-                }
-                Err(err) => {
-                    error!("Error while streaming a server stream {err:?}");
-                    break;
-                }
-            }
-        }
-
-        self.close_server_stream(transport, sequence_number, message_identifier, port_id)
+        self.streams_handler
+            .send_stream(transport, opening_message)
             .await
-            .unwrap();
-
-        Ok(())
     }
 
-    async fn send_stream(
+    pub async fn register_listener(
         &self,
-        transport: Arc<dyn Transport + Send + Sync>,
-        message: StreamMessage,
-    ) -> ServerResult<OneShotReceiver<Vec<u8>>> {
-        let (_, message_id) = parse_message_identifier(message.message_identifier);
-        let (tx, rx) = oneshot_channel();
-        {
-            let mut lock = self.ack_listeners.lock().await;
-            lock.insert(format!("{}{}", message_id, message.sequence_id), tx);
-        }
-
-        transport
-            .send(message.encode_to_vec())
-            .await
-            .map_err(|_| ServerError::TransportError)?;
-
-        Ok(rx)
+        message_id: u32,
+        callback: AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>,
+    ) {
+        let mut lock = self.listeners.lock().await;
+        lock.insert(message_id, callback);
     }
 
-    pub fn acknowledge_message(self: Arc<Self>, message_identifier: u32, payload: Vec<u8>) {
-        tokio::spawn(async move {
-            let stream_message = parse_protocol_message::<StreamMessage>(&payload).unwrap().2;
-            let listener = {
-                let mut lock = self.ack_listeners.lock().await;
-                // we should remove ack listener it just for a seq_id
-                lock.remove(&format!(
-                    "{}{}",
-                    message_identifier, stream_message.sequence_id
-                ))
-            };
-            match listener {
-                Some(sender) => sender.send(payload).unwrap(),
-                None => {
-                    debug!("> RpcServer > ack listener not found")
-                }
-            }
-        });
+    pub async fn unregister_listener(&self, message_id: u32) {
+        let mut lock = self.listeners.lock().await;
+        lock.remove(&message_id);
     }
 }
 
@@ -240,6 +187,7 @@ type StreamPackage = (RpcMessageTypes, u32, StreamMessage);
 
 pub struct ClientMessagesHandler {
     pub transport: Arc<dyn Transport + Send + Sync>,
+    pub streams_handler: Arc<StreamsHandler>,
     one_time_listeners: Mutex<HashMap<u32, OneShotSender<Vec<u8>>>>,
     listeners: Mutex<HashMap<u32, AsyncChannelSender<StreamPackage>>>,
     process_cancellation_token: CancellationToken,
@@ -252,6 +200,7 @@ impl ClientMessagesHandler {
             one_time_listeners: Mutex::new(HashMap::new()),
             process_cancellation_token: CancellationToken::new(),
             listeners: Mutex::new(HashMap::new()),
+            streams_handler: Arc::new(StreamsHandler::new()),
         }
     }
 
@@ -313,6 +262,10 @@ impl ClientMessagesHandler {
                                             error.to_string()
                                         );
                                     }
+                                } else {
+                                    self.streams_handler
+                                        .clone()
+                                        .message_acknowledged_by_peer(message_header.1, data)
                                 }
                             }
                         }
@@ -332,6 +285,32 @@ impl ClientMessagesHandler {
                 }
             }
         }
+    }
+
+    pub fn await_server_ack_open_and_send_streams<M: Message + 'static>(
+        self: Arc<Self>,
+        open_promise: OneShotReceiver<Vec<u8>>,
+        client_stream: Generator<M>,
+        port_id: u32,
+        client_message_id: u32,
+    ) {
+        let transport = self.transport.clone();
+        tokio::spawn(async move {
+            let encoded_response = open_promise.await.unwrap();
+            let stream_message = StreamMessage::decode(encoded_response.as_slice()).unwrap();
+
+            if stream_message.closed {
+                return;
+            }
+
+            let new_generator =
+                Generator::from_generator(client_stream, |item| item.encode_to_vec());
+
+            self.streams_handler
+                .send_stream_through_transport(transport, new_generator, port_id, client_message_id)
+                .await
+                .unwrap();
+        });
     }
 
     pub async fn register_one_time_listener(
@@ -355,5 +334,138 @@ impl ClientMessagesHandler {
     pub async fn unregister_listener(&self, message_id: u32) {
         let mut lock = self.listeners.lock().await;
         lock.remove(&message_id);
+    }
+}
+
+pub struct StreamsHandler {
+    ack_listeners: Mutex<HashMap<String, OneShotSender<Vec<u8>>>>,
+}
+
+impl StreamsHandler {
+    pub fn new() -> Self {
+        Self {
+            ack_listeners: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn close_stream(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        sequence_id: u32,
+        message_identifier: u32,
+        port_id: u32,
+    ) -> ServerResult<()> {
+        let close_message = StreamMessage {
+            closed: true,
+            ack: false,
+            sequence_id,
+            message_identifier: build_message_identifier(
+                RpcMessageTypes::StreamMessage as u32,
+                message_identifier,
+            ),
+            port_id,
+            payload: vec![],
+        };
+
+        transport.send(close_message.encode_to_vec()).await.unwrap();
+
+        Ok(())
+    }
+
+    pub async fn send_stream_through_transport(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        mut stream: Generator<Vec<u8>>,
+        port_id: u32,
+        message_identifier: u32,
+    ) -> ServerResult<()> {
+        let mut sequence_number = 0;
+
+        while let Some(message) = stream.next().await {
+            sequence_number += 1;
+            let current_message = StreamMessage {
+                closed: false,
+                ack: false,
+                sequence_id: sequence_number,
+                message_identifier: build_message_identifier(
+                    RpcMessageTypes::StreamMessage as u32,
+                    message_identifier,
+                ),
+                port_id,
+                payload: message,
+            };
+            let transport_cloned = transport.clone();
+
+            match self.send_stream(transport_cloned, current_message).await {
+                Ok(listener) => {
+                    let ack_message = match listener.await {
+                        Ok(msg) => match StreamMessage::decode(msg.as_slice()) {
+                            Ok(msg) => msg,
+                            Err(_) => break,
+                        },
+                        Err(_) => break,
+                    };
+                    if ack_message.ack {
+                        continue;
+                    } else if ack_message.closed {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    error!("Error while streaming a server stream {err:?}");
+                    break;
+                }
+            }
+        }
+
+        self.close_stream(transport, sequence_number, message_identifier, port_id)
+            .await
+            .unwrap();
+
+        Ok(())
+    }
+
+    async fn send_stream(
+        &self,
+        transport: Arc<dyn Transport + Send + Sync>,
+        message: StreamMessage,
+    ) -> ServerResult<OneShotReceiver<Vec<u8>>> {
+        let (_, message_id) = parse_message_identifier(message.message_identifier);
+        let (tx, rx) = oneshot_channel();
+        {
+            let mut lock = self.ack_listeners.lock().await;
+            lock.insert(format!("{}{}", message_id, message.sequence_id), tx);
+        }
+
+        transport
+            .send(message.encode_to_vec())
+            .await
+            .map_err(|_| ServerError::TransportError)?;
+
+        Ok(rx)
+    }
+
+    pub fn message_acknowledged_by_peer(
+        self: Arc<Self>,
+        message_identifier: u32,
+        payload: Vec<u8>,
+    ) {
+        tokio::spawn(async move {
+            let stream_message = parse_protocol_message::<StreamMessage>(&payload).unwrap().2;
+            let listener = {
+                let mut lock = self.ack_listeners.lock().await;
+                // we should remove ack listener it just for a seq_id
+                lock.remove(&format!(
+                    "{}{}",
+                    message_identifier, stream_message.sequence_id
+                ))
+            };
+            match listener {
+                Some(sender) => sender.send(payload).unwrap(),
+                None => {
+                    debug!("> Streams Handler > ack listener not found")
+                }
+            }
+        });
     }
 }

--- a/rpc/src/messages_handlers.rs
+++ b/rpc/src/messages_handlers.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Default)]
 pub struct ServerMessagesHandler {
     pub streams_handler: Arc<StreamsHandler>,
-    listeners: Mutex<HashMap<u32, AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>>>,
+    listeners: Mutex<HashMap<u32, AsyncChannelSender<StreamPackage>>>,
 }
 
 impl ServerMessagesHandler {

--- a/rpc/src/messages_handlers.rs
+++ b/rpc/src/messages_handlers.rs
@@ -337,6 +337,7 @@ impl ClientMessagesHandler {
     }
 }
 
+#[derive(Default)]
 pub struct StreamsHandler {
     ack_listeners: Mutex<HashMap<String, OneShotSender<Vec<u8>>>>,
 }

--- a/rpc/src/protocol/index.proto
+++ b/rpc/src/protocol/index.proto
@@ -57,6 +57,7 @@ message Request {
   fixed32	message_identifier = 1;
   fixed32	port_id = 2;
   fixed32	procedure_id = 4;
+  fixed32	client_stream = 5;
   bytes	payload = 6;
 }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -456,13 +456,13 @@ impl<Context> RpcServerPort<Context> {
         match self.procedures.get(&procedure_id) {
             Some(procedure_definition) => match procedure_definition {
                 Definition::Unary(procedure_handler) => {
-                    return Ok(Procedure::Unary(procedure_handler.clone()));
+                    Ok(Procedure::Unary(procedure_handler.clone()))
                 }
                 Definition::ServerStreams(procedure_handler) => {
-                    return Ok(Procedure::ServerStreams(procedure_handler.clone()));
+                    Ok(Procedure::ServerStreams(procedure_handler.clone()))
                 }
                 Definition::ClientStreams(procedure_handler) => {
-                    return Ok(Procedure::ClientStreams(procedure_handler.clone()));
+                    Ok(Procedure::ClientStreams(procedure_handler.clone()))
                 }
             },
             _ => Err(ServerError::ProcedureError),

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -10,10 +10,11 @@ use crate::{
         CreatePort, CreatePortResponse, DestroyPort, ModuleProcedure, Request, RequestModule,
         RequestModuleResponse, RpcMessageTypes,
     },
+    stream_protocol::StreamProtocol,
     transports::{Transport, TransportEvent},
     types::{
-        Definition, ServerModuleDeclaration, ServerModuleProcedures, ServerStreamsResponse,
-        ServiceModuleDefinition, UnaryResponse,
+        ClientStreamsRequestHandler, Definition, ServerModuleDeclaration, ServerModuleProcedures,
+        ServerStreamsRequestHandler, ServiceModuleDefinition, UnaryRequestHandler,
     },
 };
 
@@ -21,9 +22,10 @@ type PortHandlerFn<Context> = dyn Fn(&mut RpcServerPort<Context>) + Send + Sync 
 
 pub type ServerResult<T> = Result<T, ServerError>;
 
-enum Procedure {
-    Unary(UnaryResponse),
-    ServerStreams(ServerStreamsResponse),
+enum Procedure<Context> {
+    Unary(Arc<UnaryRequestHandler<Context>>),
+    ServerStreams(Arc<ServerStreamsRequestHandler<Context>>),
+    ClientStreams(Arc<ClientStreamsRequestHandler<Context>>),
 }
 
 #[derive(Debug)]
@@ -140,16 +142,15 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
         match self.ports.get(&request.port_id) {
             Some(port) => {
                 let procedure_ctx = self.context.clone();
-                let transport = transport.clone();
-                let procedure_handler =
-                    port.get_procedure(request.procedure_id, request.payload, procedure_ctx)?;
+                let transport_cloned = transport.clone();
+                let procedure_handler = port.get_procedure(request.procedure_id)?;
 
                 match procedure_handler {
                     Procedure::Unary(procedure_handler) => {
                         self.messages_handler.process_unary_request(
-                            transport,
+                            transport_cloned,
                             message_identifier,
-                            procedure_handler,
+                            procedure_handler(request.payload, procedure_ctx),
                         );
                     }
                     Procedure::ServerStreams(procedure_handler) => {
@@ -157,11 +158,43 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
                             // Cloned because the receiver of the function is an Arc. It'll be spawned in other thread and it needs to modify its state
                             .clone()
                             .process_server_streams_request(
-                                transport,
+                                transport_cloned,
                                 message_identifier,
                                 request.port_id,
-                                procedure_handler,
+                                procedure_handler(request.payload, procedure_ctx),
                             )
+                    }
+                    Procedure::ClientStreams(procedure_handler) => {
+                        let client_stream_id = request.client_stream;
+                        let stream_protocol = StreamProtocol::new(
+                            transport.clone(),
+                            request.port_id,
+                            request.client_stream,
+                        );
+
+                        let msg_handler = self.messages_handler.clone();
+                        match stream_protocol
+                            .start_processing(move || async move {
+                                msg_handler.unregister_listener(client_stream_id).await
+                            })
+                            .await
+                        {
+                            Ok(listener) => {
+                                self.messages_handler
+                                    .clone()
+                                    .process_client_streams_request(
+                                        transport_cloned,
+                                        message_identifier,
+                                        client_stream_id,
+                                        procedure_handler(
+                                            stream_protocol.to_generator(|item| item),
+                                            procedure_ctx,
+                                        ),
+                                        listener,
+                                    );
+                            }
+                            Err(_) => return Err(ServerError::TransportError),
+                        }
                     }
                 }
 
@@ -302,12 +335,21 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
                     .await?
             }
             RpcMessageTypes::DestroyPort => self.handle_destroy_port(&payload)?,
-            RpcMessageTypes::StreamAck => self
-                .messages_handler
-                .clone()
-                .acknowledge_message(message_identifier, payload),
+            RpcMessageTypes::StreamAck => {
+                // Client akcnowledged a stream message sent by Server
+                // and we should notify the waiter for the ack in order to
+                // continue sending streams to Client
+                self.messages_handler
+                    .streams_handler
+                    .clone()
+                    .message_acknowledged_by_peer(message_identifier, payload)
+            }
             RpcMessageTypes::StreamMessage => {
-                // noops
+                // Client has a client stream request type opened and we should
+                // notify our listener for the client message id that we have a new message to process
+                self.messages_handler
+                    .clone()
+                    .notify_new_client_stream(message_identifier, payload)
             }
             _ => {
                 debug!("Unknown message");
@@ -383,6 +425,9 @@ impl<Context> RpcServerPort<Context> {
                             Definition::ServerStreams(procedure) => self
                                 .procedures
                                 .insert(current_id, Definition::ServerStreams(procedure.clone())),
+                            &Definition::ClientStreams(ref procedure) => self
+                                .procedures
+                                .insert(current_id, Definition::ClientStreams(procedure.clone())),
                         };
                         server_module_declaration
                             .procedures
@@ -407,20 +452,18 @@ impl<Context> RpcServerPort<Context> {
     }
 
     /// It will look up the procedure id in the port's `procedures` and return the procedure's handler
-    fn get_procedure(
-        &self,
-        procedure_id: u32,
-        payload: Vec<u8>,
-        context: Arc<Context>,
-    ) -> ServerResult<Procedure> {
+    fn get_procedure(&self, procedure_id: u32) -> ServerResult<Procedure<Context>> {
         match self.procedures.get(&procedure_id) {
             Some(procedure_definition) => match procedure_definition {
                 Definition::Unary(procedure_handler) => {
-                    Ok(Procedure::Unary(procedure_handler(payload, context)))
+                    return Ok(Procedure::Unary(procedure_handler.clone()));
                 }
-                Definition::ServerStreams(procedure_handler) => Ok(Procedure::ServerStreams(
-                    procedure_handler(payload, context),
-                )),
+                Definition::ServerStreams(procedure_handler) => {
+                    return Ok(Procedure::ServerStreams(procedure_handler.clone()));
+                }
+                Definition::ClientStreams(procedure_handler) => {
+                    return Ok(Procedure::ClientStreams(procedure_handler.clone()));
+                }
             },
             _ => Err(ServerError::ProcedureError),
         }

--- a/rpc/src/stream_protocol.rs
+++ b/rpc/src/stream_protocol.rs
@@ -1,109 +1,110 @@
-use std::{
-    future::Future,
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use std::{future::Future, sync::Arc};
 
 use log::debug;
 use prost::Message;
 
-use async_channel::{
-    unbounded as async_unbounded, Receiver as AsyncChannelReceiver, Sender as AsyncChannelSender,
+use tokio::{
+    select,
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
 };
-use tokio::select;
+
+use async_channel::{unbounded, Receiver as AsyncChannelReceiver, Sender as AsyncChannelSender};
+
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     protocol::{parse::build_message_identifier, RpcMessageTypes, StreamMessage},
     transports::{Transport, TransportError},
+    CommonError,
 };
 
-pub struct Stream<M: Message + Default>(pub StreamProtocol<M>);
-
-impl<M: Message + Default> Deref for Stream<M> {
-    type Target = StreamProtocol<M>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<M: Message + Default> DerefMut for Stream<M> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-pub struct StreamProtocol<M: Message + Default> {
+pub struct StreamProtocol {
     port_id: u32,
     message_number: u32,
     last_received_sequence_id: u32,
     is_remote_closed: bool,
     was_open: bool,
-    channel: (AsyncChannelSender<M>, AsyncChannelReceiver<M>),
+    pub generator: (Generator<Vec<u8>>, GeneratorYielder<Vec<u8>>),
     transport: Arc<dyn Transport + Send + Sync>,
-    messages_processor: AsyncChannelReceiver<(RpcMessageTypes, u32, StreamMessage)>,
     process_cancellation_token: CancellationToken,
 }
 
-impl<M: Message + Default + 'static> StreamProtocol<M> {
-    pub(crate) fn create(
+impl StreamProtocol {
+    pub(crate) fn new(
         transport: Arc<dyn Transport + Send + Sync>,
         port_id: u32,
         message_number: u32,
-    ) -> (
-        Self,
-        AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>,
-    ) {
-        let (tx, rx) = async_unbounded();
-
-        (
-            Self {
-                last_received_sequence_id: 0,
-                is_remote_closed: false,
-                was_open: false,
-                channel: async_unbounded(),
-                transport,
-                message_number,
-                port_id,
-                messages_processor: rx,
-                process_cancellation_token: CancellationToken::new(),
-            },
-            tx,
-        )
+    ) -> Self {
+        Self {
+            last_received_sequence_id: 0,
+            is_remote_closed: false,
+            was_open: false,
+            generator: Generator::create(),
+            transport,
+            message_number,
+            port_id,
+            process_cancellation_token: CancellationToken::new(),
+        }
     }
 
-    pub async fn next(&mut self) -> Option<M> {
-        match self.channel.1.recv().await {
-            Ok(msg) => {
-                self.last_received_sequence_id += 1;
-                self.was_open = true;
-                let stream_message = StreamMessage {
-                    port_id: self.port_id,
-                    sequence_id: self.last_received_sequence_id,
-                    message_identifier: build_message_identifier(
-                        RpcMessageTypes::StreamAck as u32,
-                        self.message_number,
-                    ),
-                    payload: vec![],
-                    closed: false,
-                    ack: true,
-                };
-
-                self.transport
-                    .send(stream_message.encode_to_vec())
-                    .await
-                    .unwrap();
-
-                Some(msg)
-            }
-            Err(_) => {
+    async fn next(&mut self) -> Option<Vec<u8>> {
+        select! {
+            _ = self.process_cancellation_token.cancelled() =>  {
+                self.generator.0.close();
                 self.is_remote_closed = true;
-                None
+                return None;
+            }
+            message = self.generator.0.next() => {
+                match message {
+                    Some(msg) => {
+                        self.last_received_sequence_id += 1;
+                        self.was_open = true;
+                        // Ack Message to let know the peer that we are ready to receive another message
+                        let stream_message = StreamMessage {
+                            port_id: self.port_id,
+                            sequence_id: self.last_received_sequence_id,
+                            message_identifier: build_message_identifier(
+                                RpcMessageTypes::StreamAck as u32,
+                                self.message_number,
+                            ),
+                            payload: vec![],
+                            closed: false,
+                            ack: true,
+                        };
+
+                        self.transport
+                            .send(stream_message.encode_to_vec())
+                            .await
+                            .unwrap();
+
+
+                        Some(msg)
+                    }
+                    None => {
+                        self.is_remote_closed = true;
+                        None
+                    }
+                }
             }
         }
     }
 
-    pub(crate) async fn acknowledge_open(&self) -> Result<(), TransportError> {
+    pub fn to_generator<O: Send + Sync + 'static, F: Fn(Vec<u8>) -> O + Send + Sync + 'static>(
+        mut self,
+        transformer: F,
+    ) -> Generator<O> {
+        let (generator, generator_yielder) = Generator::create();
+        tokio::spawn(async move {
+            while let Some(item) = self.next().await {
+                let new_item = transformer(item);
+                generator_yielder.insert(new_item).await.unwrap();
+            }
+        });
+
+        generator
+    }
+
+    async fn acknowledge_open(&self) -> Result<(), TransportError> {
         let stream_message = StreamMessage {
             port_id: self.port_id,
             sequence_id: self.last_received_sequence_id,
@@ -119,18 +120,24 @@ impl<M: Message + Default + 'static> StreamProtocol<M> {
         self.transport.send(stream_message.encode_to_vec()).await
     }
 
-    pub fn close(&self) {
-        self.channel.1.close();
+    pub fn close(&mut self) {
+        self.generator.0.close();
         self.process_cancellation_token.cancel();
     }
 
-    pub(crate) fn start_processing<F: Future + Send, Callback: FnOnce() -> F + Send + 'static>(
+    pub(crate) async fn start_processing<
+        F: Future + Send,
+        Callback: FnOnce() -> F + Send + 'static,
+    >(
         &self,
         callback: Callback,
-    ) {
+    ) -> Result<AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>, CommonError> {
+        if let Err(_) = self.acknowledge_open().await {
+            return Err(CommonError::TransportError);
+        }
         let token = self.process_cancellation_token.clone();
-        let messages_processor = self.messages_processor.clone();
-        let internal_channel = (self.channel.0.clone(), self.channel.1.clone());
+        let (messages_listener, messages_processor) = unbounded();
+        let internal_channel = self.generator.1.clone();
         tokio::spawn(async move {
             let token_cloned = token.clone();
             select! {
@@ -144,26 +151,90 @@ impl<M: Message + Default + 'static> StreamProtocol<M> {
                 }
             }
         });
+
+        Ok(messages_listener)
     }
 
     async fn process_messages(
         messages_processor: AsyncChannelReceiver<(RpcMessageTypes, u32, StreamMessage)>,
-        internal_channel: (AsyncChannelSender<M>, AsyncChannelReceiver<M>),
+        internal_channel_sender: GeneratorYielder<Vec<u8>>,
         cancellation_token: CancellationToken,
     ) {
         while let Ok(message) = messages_processor.recv().await {
             if matches!(message.0, RpcMessageTypes::StreamMessage) {
                 if message.2.closed {
-                    internal_channel.1.close();
+                    cancellation_token.cancel();
                     messages_processor.close();
                 } else {
-                    let decoded = M::decode(message.2.payload.as_slice()).unwrap();
-                    internal_channel.0.send(decoded).await.unwrap();
+                    internal_channel_sender
+                        .insert(message.2.payload)
+                        .await
+                        .unwrap();
                 }
             } else if matches!(message.0, RpcMessageTypes::RemoteErrorResponse) {
                 cancellation_token.cancel();
+                messages_processor.close();
                 // TOOD: Communicate error
             }
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum GeneratorError {
+    UnableToInsert,
+}
+
+pub struct Generator<M>(UnboundedReceiver<M>);
+
+impl<M: Send + Sync + 'static> Generator<M> {
+    pub fn create() -> (Self, GeneratorYielder<M>) {
+        let channel = unbounded_channel();
+        (Self(channel.1), GeneratorYielder::new(channel.0))
+    }
+
+    // TODO: could it be a trait and reuse for other structs?
+    pub fn from_generator<O: Send + Sync + 'static, F: Fn(M) -> O + Send + Sync + 'static>(
+        mut old_generator: Generator<M>,
+        transformer: F,
+    ) -> Generator<O> {
+        let (generator, generator_yielder) = Generator::create();
+        tokio::spawn(async move {
+            while let Some(item) = old_generator.next().await {
+                let new_item = transformer(item);
+                generator_yielder.insert(new_item).await.unwrap();
+            }
+        });
+
+        generator
+    }
+
+    pub async fn next(&mut self) -> Option<M> {
+        self.0.recv().await
+    }
+
+    pub fn close(&mut self) {
+        self.0.close()
+    }
+}
+
+pub struct GeneratorYielder<M>(UnboundedSender<M>);
+
+impl<M> GeneratorYielder<M> {
+    fn new(sender: UnboundedSender<M>) -> Self {
+        Self(sender)
+    }
+
+    pub async fn insert(&self, item: M) -> Result<(), GeneratorError> {
+        match self.0.send(item) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(GeneratorError::UnableToInsert),
+        }
+    }
+}
+
+impl<M> Clone for GeneratorYielder<M> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }

--- a/rpc/src/stream_protocol.rs
+++ b/rpc/src/stream_protocol.rs
@@ -52,7 +52,7 @@ impl StreamProtocol {
             _ = self.process_cancellation_token.cancelled() =>  {
                 self.generator.0.close();
                 self.is_remote_closed = true;
-                return None;
+                None
             }
             message = self.generator.0.next() => {
                 match message {
@@ -132,7 +132,7 @@ impl StreamProtocol {
         &self,
         callback: Callback,
     ) -> Result<AsyncChannelSender<(RpcMessageTypes, u32, StreamMessage)>, CommonError> {
-        if let Err(_) = self.acknowledge_open().await {
+        if self.acknowledge_open().await.is_err() {
             return Err(CommonError::TransportError);
         }
         let token = self.process_cancellation_token.clone();

--- a/rpc/src/types/mod.rs
+++ b/rpc/src/types/mod.rs
@@ -1,23 +1,33 @@
 use core::future::Future;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
-use tokio::sync::mpsc::UnboundedReceiver;
+use crate::stream_protocol::Generator;
 
 pub type Response<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+pub type CommonPayload = Vec<u8>;
 
 pub type UnaryResponse = Response<Vec<u8>>;
 
 pub type UnaryRequestHandler<Context> =
-    dyn Fn(Vec<u8>, Arc<Context>) -> UnaryResponse + Send + Sync;
+    dyn Fn(CommonPayload, Arc<Context>) -> UnaryResponse + Send + Sync;
 
-pub type ServerStreamsResponse = Response<UnboundedReceiver<Vec<u8>>>;
+pub type ServerStreamsResponse = Response<Generator<Vec<u8>>>;
 
 pub type ServerStreamsRequestHandler<Context> =
-    dyn Fn(Vec<u8>, Arc<Context>) -> ServerStreamsResponse + Send + Sync;
+    dyn Fn(CommonPayload, Arc<Context>) -> ServerStreamsResponse + Send + Sync;
+
+pub type ClientStreamsPayload = Generator<Vec<u8>>;
+
+pub type ClientStreamsResponse = Response<Vec<u8>>;
+
+pub type ClientStreamsRequestHandler<Context> =
+    dyn Fn(ClientStreamsPayload, Arc<Context>) -> ClientStreamsResponse + Send + Sync;
 
 pub enum Definition<Context> {
     Unary(Arc<UnaryRequestHandler<Context>>),
     ServerStreams(Arc<ServerStreamsRequestHandler<Context>>),
+    ClientStreams(Arc<ClientStreamsRequestHandler<Context>>),
 }
 
 pub struct ServiceModuleDefinition<Context> {
@@ -45,10 +55,7 @@ impl<Context> ServiceModuleDefinition<Context> {
     }
 
     pub fn add_server_streams<
-        H: Fn(
-                Vec<u8>,
-                Arc<Context>,
-            ) -> Pin<Box<dyn Future<Output = UnboundedReceiver<Vec<u8>>> + Send>>
+        H: Fn(Vec<u8>, Arc<Context>) -> Pin<Box<dyn Future<Output = Generator<Vec<u8>>> + Send>>
             + Send
             + Sync
             + 'static,
@@ -58,6 +65,19 @@ impl<Context> ServiceModuleDefinition<Context> {
         handler: H,
     ) {
         self.add_definition(name, Definition::ServerStreams(Arc::new(handler)));
+    }
+
+    pub fn add_client_streams<
+        H: Fn(Generator<Vec<u8>>, Arc<Context>) -> Pin<Box<dyn Future<Output = Vec<u8>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >(
+        &mut self,
+        name: &str,
+        handler: H,
+    ) {
+        self.add_definition(name, Definition::ClientStreams(Arc::new(handler)));
     }
 
     fn add_definition(&mut self, name: &str, definition: Definition<Context>) {


### PR DESCRIPTION
This PR: 
- add client streams procedures 
- separate logic for streams handler so that it can be reusable between `ServerMessagesHandler` and `ClientMessagesHandler`
- add `Generator` concept and struct+impl so that we can reuse login and avoid calling directly `tokio::mspc::unbounded_channel`
- replace `StreamProtocol` with `Generator` as a parameter in some pieces of code. It wasn't good to use `StreamProtocol`, we had to use a tiny and simple data structure as `Generator` for simplicity
- `StreamProtocol` can be easily turned into a `Generator` (`to_generator` function)

**This branch contains all the work done in #35** 
Closes #10 