### PR TITLE
feat: multiple transports support

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{env, time::Duration};
 
 use integration::{
     codegen::{
@@ -104,14 +104,27 @@ async fn create_quic_transports() -> (QuicTransport, QuicTransport) {
 
 #[tokio::main]
 async fn main() {
-    println!("--- Running example with Memory Transports ---");
-    run_with_transports(create_memory_transports()).await;
-
-    println!("--- Running example with Web Socket Transports ---");
-    run_with_transports(create_web_socket_transports().await).await;
-
-    println!("--- Running example with QUIC Transports ---");
-    run_with_transports(create_quic_transports().await).await;
+    let args: Vec<String> = env::args().collect();
+    let example = args.get(1);
+    if let Some(example) = example {
+        if example == "memory" {
+            println!("--- Running example with Memory Transports ---");
+            run_with_transports(create_memory_transports()).await;
+        } else if example == "ws" {
+            println!("--- Running example with Web Socket Transports ---");
+            run_with_transports(create_web_socket_transports().await).await;
+        } else if example == "quic" {
+            println!("--- Running example with QUIC Transports ---");
+            run_with_transports(create_quic_transports().await).await;
+        }
+    } else {
+        println!("--- Running example with Memory Transports ---");
+        run_with_transports(create_memory_transports()).await;
+        println!("--- Running example with Web Socket Transports ---");
+        run_with_transports(create_web_socket_transports().await).await;
+        println!("--- Running example with QUIC Transports ---");
+        run_with_transports(create_quic_transports().await).await;
+    }
 }
 
 async fn run_with_transports<T: Transport + Send + Sync + 'static>(
@@ -158,7 +171,7 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
         println!("> GetBook: Concurrent Example");
 
         let get_book_payload = GetBookRequest { isbn: 1000 };
-        let get_book_payload_2 = GetBookRequest { isbn: 1010 };
+        let get_book_payload_2 = GetBookRequest { isbn: 1001 };
 
         join!(
             book_service_module.get_book(get_book_payload),

--- a/justfile
+++ b/justfile
@@ -1,3 +1,3 @@
 # Run integration example
 run-integration:
-  cd examples/integration && cargo run
+  cd examples/integration && cargo run -- memory

--- a/justfile
+++ b/justfile
@@ -1,3 +1,3 @@
 # Run integration example
-run-integration:
-  cd examples/integration && cargo run -- memory
+run-integration transport="":
+  cd examples/integration && cargo run -- {{transport}}

--- a/rpc/src/transports/memory.rs
+++ b/rpc/src/transports/memory.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use super::{Transport, TransportError, TransportEvent};
 
 pub struct MemoryTransport {
+    id: Option<u32>,
     connected: AtomicBool,
     sender: Sender<Vec<u8>>,
     receiver: Receiver<Vec<u8>>,
@@ -14,6 +15,7 @@ pub struct MemoryTransport {
 impl MemoryTransport {
     fn new(sender: Sender<Vec<u8>>, receiver: Receiver<Vec<u8>>) -> Self {
         Self {
+            id: None,
             sender,
             receiver,
             connected: AtomicBool::new(false),
@@ -63,5 +65,13 @@ impl Transport for MemoryTransport {
 
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
+    }
+
+    fn set_id(&mut self, id: u32) {
+        self.id.replace(id);
+    }
+
+    fn get_id(&self) -> u32 {
+        self.id.unwrap()
     }
 }

--- a/rpc/src/transports/mod.rs
+++ b/rpc/src/transports/mod.rs
@@ -41,5 +41,8 @@ pub trait Transport {
         }
     }
 
+    fn set_id(&mut self, id: u32);
+    fn get_id(&self) -> u32;
+
     fn is_connected(&self) -> bool;
 }

--- a/rpc/src/transports/quic.rs
+++ b/rpc/src/transports/quic.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 use super::{Transport, TransportError, TransportEvent};
 
 pub struct QuicTransport {
+    id: Option<u32>,
     send: Mutex<SendStream>,
     receiver: Mutex<RecvStream>,
     ready: AtomicBool,
@@ -19,6 +20,7 @@ pub struct QuicTransport {
 impl QuicTransport {
     fn new((send, receiver): (SendStream, RecvStream)) -> Self {
         Self {
+            id: None,
             send: Mutex::new(send),
             receiver: Mutex::new(receiver),
             ready: AtomicBool::new(false),
@@ -108,5 +110,13 @@ impl Transport for QuicTransport {
 
     fn is_connected(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
+    }
+
+    fn set_id(&mut self, id: u32) {
+        self.id.replace(id);
+    }
+
+    fn get_id(&self) -> u32 {
+        self.id.unwrap()
     }
 }

--- a/rpc/src/transports/web_socket.rs
+++ b/rpc/src/transports/web_socket.rs
@@ -20,6 +20,7 @@ type WriteStream =
 type ReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 pub struct WebSocketTransport {
+    id: Option<u32>,
     read: Mutex<ReadStream>,
     write: Mutex<WriteStream>,
     ready: AtomicBool,
@@ -29,6 +30,7 @@ impl WebSocketTransport {
     fn create(ws: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
         let (write, read) = ws.split();
         Self {
+            id: None,
             read: Mutex::new(read),
             write: Mutex::new(write),
             ready: AtomicBool::new(false),
@@ -110,5 +112,13 @@ impl Transport for WebSocketTransport {
 
     fn is_connected(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
+    }
+
+    fn set_id(&mut self, id: u32) {
+        self.id.replace(id);
+    }
+
+    fn get_id(&self) -> u32 {
+        self.id.unwrap()
     }
 }


### PR DESCRIPTION
This PR:
- adds server events collector (to collect events like a new transport attached)
- adds a channel to communicate every transport running and the server

(this contains all work done in #37 and #39)

Closes #34 