### PR TITLE
feat: improvements and fix issues

### DIFF
--- a/examples/integration-multi-lang/Cargo.toml
+++ b/examples/integration-multi-lang/Cargo.toml
@@ -24,5 +24,5 @@ rcgen.workspace = true
 prost-build = "0.11.5"
 
 [[bin]]
-name = "integration"
+name = "integration-multilang"
 path = "src/main.rs"

--- a/examples/integration-multi-lang/rpc-client-ts/index.ts
+++ b/examples/integration-multi-lang/rpc-client-ts/index.ts
@@ -5,11 +5,11 @@ import { WebSocket } from 'ws';
 import { Book, BookServiceDefinition, GetBookRequest } from "./api";
 import expect from "expect";
 
-console.log("> Creating client and server WebSocket")
+console.log("> Creating WebSocket client")
 let ws = new WebSocket('ws://127.0.0.1:8080');
 const clientSocket = WebSocketTransport(ws)
 
-console.log("> Creating client")
+console.log("> Creating RPC client")
 const clientPromise = createRpcClient(clientSocket)
 
 async function* bookRequestGenerator() {

--- a/examples/integration-multi-lang/src/codegen/server.rs
+++ b/examples/integration-multi-lang/src/codegen/server.rs
@@ -52,7 +52,6 @@ impl BookServiceCodeGen {
                 let response = service
                     .get_book(GetBookRequest::decode(request.as_slice()).unwrap(), context)
                     .await;
-                println!("> Service Definition > Get Book > response: {:?}", response);
                 response.encode_to_vec()
             })
         });

--- a/examples/integration-multi-lang/src/main.rs
+++ b/examples/integration-multi-lang/src/main.rs
@@ -46,10 +46,10 @@ async fn main() {
 }
 
 async fn run_ws_example() {
-    let (ws_server, mut connection_listener) = WebSocketServer::new("127.0.0.1:8080");
+    let ws_server = WebSocketServer::new("127.0.0.1:8080");
 
     // Listen in background task
-    ws_server.listen().await.unwrap();
+    let mut connection_listener = ws_server.listen().await.unwrap();
 
     println!("> RpcServer > Server transport is ready");
 

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -15,7 +15,10 @@ use rpc_rust::{
     server::{RpcServer, RpcServerPort},
     stream_protocol::Generator,
     transports::{
-        self, memory::MemoryTransport, quic::QuicTransport, web_socket::WebSocketTransport,
+        self,
+        memory::MemoryTransport,
+        quic::QuicTransport,
+        web_socket::{WebSocketClient, WebSocketServer, WebSocketTransport},
         Transport,
     },
 };
@@ -59,23 +62,7 @@ fn create_memory_transports() -> (MemoryTransport, MemoryTransport) {
     transports::memory::MemoryTransport::create()
 }
 
-async fn create_web_socket_transports() -> (WebSocketTransport, WebSocketTransport) {
-    let server_handle = tokio::spawn(async { WebSocketTransport::listen("127.0.0.1:8080").await });
-    let client_handle =
-        tokio::spawn(async { WebSocketTransport::connect("ws://127.0.0.1:8080").await });
-
-    let server = server_handle
-        .await
-        .expect("Thread to finish")
-        .expect("Server to accept client connection");
-
-    let client = client_handle
-        .await
-        .expect("Thread to finish")
-        .expect("Client to establish connection");
-    (client, server)
-}
-
+#[allow(dead_code)]
 async fn create_quic_transports() -> (QuicTransport, QuicTransport) {
     let server_handle = tokio::spawn(async {
         let (cert, keys) = generate_self_signed_cert();
@@ -110,163 +97,36 @@ async fn main() {
     if let Some(example) = example {
         if example == "memory" {
             println!("--- Running example with Memory Transports ---");
-            run_with_transports(create_memory_transports()).await;
+            run_memory_transport().await;
         } else if example == "ws" {
             println!("--- Running example with Web Socket Transports ---");
-            run_with_transports(create_web_socket_transports().await).await;
-        } else if example == "quic" {
-            println!("--- Running example with QUIC Transports ---");
-            run_with_transports(create_quic_transports().await).await;
+            run_ws_tramsport().await;
         }
+        // TODO: fix QUIC transport (similar to ws fix)
+        // } else if example == "quic" {
+        //     // println!("--- Running example with QUIC Transports ---");
+        //     // run_with_transports(TransportType::QUIC).await;
+        //}
     } else {
         println!("--- Running example with Memory Transports ---");
-        run_with_transports(create_memory_transports()).await;
+        run_memory_transport().await;
         println!("--- Running example with Web Socket Transports ---");
-        run_with_transports(create_web_socket_transports().await).await;
-        println!("--- Running example with QUIC Transports ---");
-        run_with_transports(create_quic_transports().await).await;
+        run_ws_tramsport().await;
+        // TODO: fix QUIC transport (similar to ws fix)
+        // println!("--- Running example with QUIC Transports ---");
+        // run_with_transports(TransportType::QUIC).await;
     }
 }
 
-async fn run_with_transports<T: Transport + Send + Sync + 'static>(
-    (client_transport, server_transport): (T, T),
-) {
+async fn run_memory_transport() {
+    let (client_transport, server_transport) = create_memory_transports();
     let cancellation_token = CancellationToken::new();
     // Another client to test multiple transports server feature
-    let client_2_transport = create_memory_transports();
+    let (client_2_transport, server_2_transport) = create_memory_transports();
     let cloned_token = cancellation_token.clone();
+
     let client_handle = tokio::spawn(async move {
-        let mut client = RpcClient::new(client_transport).await.unwrap();
-
-        let mut client_2 = RpcClient::new(client_2_transport.0).await.unwrap();
-
-        println!("> Creating Port");
-        let client_port = match client.create_port("TEST_PORT").await {
-            Ok(port) => {
-                println!(
-                    "> Create Port > Created successfully > Port name: {}",
-                    port.port_name
-                );
-                port
-            }
-            Err(err) => {
-                println!("> Create Port > Error on creating the port: {:?}", err);
-                panic!()
-            }
-        };
-
-        assert_eq!(client_port.port_name, "TEST_PORT");
-        println!("> Port created");
-
-        println!("> Creating Port 2");
-        let client_port_2 = match client_2.create_port("TEST_PORT_2").await {
-            Ok(port) => {
-                println!(
-                    "> Create Port > Created successfully > Port name: {}",
-                    port.port_name
-                );
-                port
-            }
-            Err(err) => {
-                println!("> Create Port > Error on creating the port: {:?}", err);
-                panic!()
-            }
-        };
-
-        assert_eq!(client_port_2.port_name, "TEST_PORT_2");
-        println!("> Port 2 created");
-
-        println!("> Calling load module");
-        let book_service_module = client_port
-            .load_module::<BookServiceClient>("BookService")
-            .await
-            .unwrap();
-
-        println!("> Calling load module for client 2");
-        let book_service_module_2 = client_port_2
-            .load_module::<BookServiceClient>("BookService")
-            .await
-            .unwrap();
-
-        println!("> Unary > Request > GetBook");
-
-        let get_book_payload = GetBookRequest { isbn: 1000 };
-        let response = book_service_module.get_book(get_book_payload).await;
-
-        println!("> Unary > Response > GetBook: {:?}", response);
-
-        assert_eq!(response.isbn, 1000);
-        assert_eq!(response.title, "Rust: crash course");
-        assert_eq!(response.author, "mr steve");
-
-        println!("> Client 2 > Unary > Request > GetBook");
-
-        let get_book_payload = GetBookRequest { isbn: 1004 };
-        let response = book_service_module_2.get_book(get_book_payload).await;
-
-        println!("> Client 2 > Unary > Response > GetBook: {:?}", response);
-
-        assert_eq!(response.isbn, 1004);
-        assert_eq!(response.title, "Smart Contracts 101");
-        assert_eq!(response.author, "buterin");
-
-        drop(client_2);
-
-        println!("> GetBook: Concurrent Example");
-
-        let get_book_payload = GetBookRequest { isbn: 1000 };
-        let get_book_payload_2 = GetBookRequest { isbn: 1001 };
-
-        join!(
-            book_service_module.get_book(get_book_payload),
-            book_service_module.get_book(get_book_payload_2)
-        );
-
-        println!("> Server Streams > Request > QueryBooks");
-
-        let query_books_payload = QueryBooksRequest {
-            author_prefix: "mr".to_string(),
-        };
-
-        let mut response_stream = book_service_module.query_books(query_books_payload).await;
-
-        while let Some(book) = response_stream.next().await {
-            println!("> Server Streams > Response > QueryBooks {:?}", book)
-        }
-
-        println!("> Client Streams > Request > GetBookStream");
-        let (generator, generator_yielder) = Generator::create();
-        tokio::spawn(async move {
-            for _ in 0..4 {
-                sleep(Duration::from_millis(300)).await;
-                println!("> Client Stream > GetBookStream > Sending stream payload");
-                generator_yielder
-                    .insert(GetBookRequest { isbn: 1000 })
-                    .await
-                    .unwrap();
-            }
-        });
-        let response = book_service_module.get_book_stream(generator).await;
-
-        println!("> Client Streams > Response > GetBookStream {response:?}");
-
-        println!("> BiDir Streams > Request > QueryBooksStream");
-        let (generator, generator_yielder) = Generator::create();
-        tokio::spawn(async move {
-            for i in 0..4 {
-                sleep(Duration::from_millis(300)).await;
-                println!("> BiDir Stream > QueryBooksStream > Sending stream payload");
-                generator_yielder
-                    .insert(GetBookRequest { isbn: (1000 + i) })
-                    .await
-                    .unwrap();
-            }
-        });
-        let mut response = book_service_module.query_books_streams(generator).await;
-
-        while let Some(book) = response.next().await {
-            println!("> BiDir Streams > Response > QueryBooksStream {:?}", book)
-        }
+        handle_client_connection((client_transport, client_2_transport)).await;
         cloned_token.cancel();
     });
 
@@ -275,13 +135,13 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
             hardcoded_database: create_db(),
         };
 
-        // 2- Create Server with Transport
         let mut server = RpcServer::create(ctx);
-        // 3- Server listen to Create Port request
         server.set_handler(|port: &mut RpcServerPort<MyExampleContext>| {
             BookServiceCodeGen::register_service(port, book_service::BookService {})
         });
 
+        // Not needed to use the server events sender it can be attached direcrly
+        // Since it doesn't have to anything or wait anything in background
         match server.attach_transport(server_transport) {
             Ok(_) => {
                 println!("> RpcServer > first transport attached successfully");
@@ -292,7 +152,7 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
             }
         }
 
-        match server.attach_transport(client_2_transport.1) {
+        match server.attach_transport(server_2_transport) {
             Ok(_) => {
                 println!("> RpcServer > second transport attached successfully");
             }
@@ -313,5 +173,209 @@ async fn run_with_transports<T: Transport + Send + Sync + 'static>(
         _ =  server_handle => {
             println!("Server terminated unexpectedly")
         }
+    }
+}
+
+async fn run_ws_tramsport() {
+    let (ws_server, mut connection_listener) = WebSocketServer::new("127.0.0.1:8080");
+
+    ws_server.listen().await.unwrap();
+
+    let cancellation_token = CancellationToken::new();
+    // Another client to test multiple transports server feature
+    let cloned_token = cancellation_token.clone();
+
+    let client_handle = tokio::spawn(async move {
+        let client_connection = WebSocketClient::connect("ws://127.0.0.1:8080")
+            .await
+            .unwrap();
+
+        let client_transport = WebSocketTransport::new(client_connection);
+
+        let client_connection = WebSocketClient::connect("ws://127.0.0.1:8080")
+            .await
+            .unwrap();
+        let client_2_transport = WebSocketTransport::new(client_connection);
+
+        handle_client_connection((client_transport, client_2_transport)).await;
+
+        cloned_token.cancel();
+    });
+
+    let server_handle = tokio::spawn(async {
+        let ctx = MyExampleContext {
+            hardcoded_database: create_db(),
+        };
+
+        let mut server = RpcServer::create(ctx);
+        server.set_handler(|port: &mut RpcServerPort<MyExampleContext>| {
+            BookServiceCodeGen::register_service(port, book_service::BookService {})
+        });
+
+        // It has to use the server events sender to attach transport because it has to wait for client connections
+        // and keep waiting for new ones
+        let server_events_sender = server.get_server_events_sender();
+        tokio::spawn(async move {
+            while let Some(Ok(connection)) = connection_listener.recv().await {
+                let transport = WebSocketTransport::new(connection);
+                match server_events_sender.send_attach_transport(transport) {
+                    Ok(_) => {
+                        println!("> RpcServer > transport attached successfully");
+                    }
+                    Err(_) => {
+                        println!("> RpcServer > unable to attach transport");
+                        panic!()
+                    }
+                }
+            }
+        });
+
+        server.run().await;
+    });
+
+    client_handle.await.unwrap();
+    select! {
+        _ = cancellation_token.cancelled() => {
+            println!("Example finished manually")
+        },
+        _ =  server_handle => {
+            println!("Server terminated unexpectedly")
+        }
+    }
+}
+
+async fn handle_client_connection<T: Transport + Send + Sync + 'static>(
+    (client_transport, client_2_transport): (T, T),
+) {
+    let mut client = RpcClient::new(client_transport).await.unwrap();
+
+    let mut client_2 = RpcClient::new(client_2_transport).await.unwrap();
+
+    println!("> Creating Port");
+    let client_port = match client.create_port("TEST_PORT").await {
+        Ok(port) => {
+            println!(
+                "> Create Port > Created successfully > Port name: {}",
+                port.port_name
+            );
+            port
+        }
+        Err(err) => {
+            println!("> Create Port > Error on creating the port: {:?}", err);
+            panic!()
+        }
+    };
+
+    assert_eq!(client_port.port_name, "TEST_PORT");
+    println!("> Port created");
+
+    println!("> Creating Port 2");
+    let client_port_2 = match client_2.create_port("TEST_PORT_2").await {
+        Ok(port) => {
+            println!(
+                "> Create Port > Created successfully > Port name: {}",
+                port.port_name
+            );
+            port
+        }
+        Err(err) => {
+            println!("> Create Port > Error on creating the port: {:?}", err);
+            panic!()
+        }
+    };
+
+    assert_eq!(client_port_2.port_name, "TEST_PORT_2");
+    println!("> Port 2 created");
+
+    println!("> Calling load module");
+    let book_service_module = client_port
+        .load_module::<BookServiceClient>("BookService")
+        .await
+        .unwrap();
+
+    println!("> Calling load module for client 2");
+    let book_service_module_2 = client_port_2
+        .load_module::<BookServiceClient>("BookService")
+        .await
+        .unwrap();
+
+    println!("> Unary > Request > GetBook");
+
+    let get_book_payload = GetBookRequest { isbn: 1000 };
+    let response = book_service_module.get_book(get_book_payload).await;
+
+    println!("> Unary > Response > GetBook: {:?}", response);
+
+    assert_eq!(response.isbn, 1000);
+    assert_eq!(response.title, "Rust: crash course");
+    assert_eq!(response.author, "mr steve");
+
+    println!("> Client 2 > Unary > Request > GetBook");
+
+    let get_book_payload = GetBookRequest { isbn: 1004 };
+    let response = book_service_module_2.get_book(get_book_payload).await;
+
+    println!("> Client 2 > Unary > Response > GetBook: {:?}", response);
+
+    assert_eq!(response.isbn, 1004);
+    assert_eq!(response.title, "Smart Contracts 101");
+    assert_eq!(response.author, "buterin");
+
+    drop(client_2);
+
+    println!("> GetBook: Concurrent Example");
+
+    let get_book_payload = GetBookRequest { isbn: 1000 };
+    let get_book_payload_2 = GetBookRequest { isbn: 1001 };
+
+    join!(
+        book_service_module.get_book(get_book_payload),
+        book_service_module.get_book(get_book_payload_2)
+    );
+
+    println!("> Server Streams > Request > QueryBooks");
+
+    let query_books_payload = QueryBooksRequest {
+        author_prefix: "mr".to_string(),
+    };
+
+    let mut response_stream = book_service_module.query_books(query_books_payload).await;
+
+    while let Some(book) = response_stream.next().await {
+        println!("> Server Streams > Response > QueryBooks {:?}", book)
+    }
+
+    println!("> Client Streams > Request > GetBookStream");
+    let (generator, generator_yielder) = Generator::create();
+    tokio::spawn(async move {
+        for _ in 0..4 {
+            sleep(Duration::from_millis(300)).await;
+            println!("> Client Stream > GetBookStream > Sending stream payload");
+            generator_yielder
+                .insert(GetBookRequest { isbn: 1000 })
+                .await
+                .unwrap();
+        }
+    });
+    let response = book_service_module.get_book_stream(generator).await;
+
+    println!("> Client Streams > Response > GetBookStream {response:?}");
+
+    println!("> BiDir Streams > Request > QueryBooksStream");
+    let (generator, generator_yielder) = Generator::create();
+    tokio::spawn(async move {
+        for i in 0..4 {
+            sleep(Duration::from_millis(300)).await;
+            println!("> BiDir Stream > QueryBooksStream > Sending stream payload");
+            generator_yielder
+                .insert(GetBookRequest { isbn: (1000 + i) })
+                .await
+                .unwrap();
+        }
+    });
+    let mut response = book_service_module.query_books_streams(generator).await;
+
+    while let Some(book) = response.next().await {
+        println!("> BiDir Streams > Response > QueryBooksStream {:?}", book)
     }
 }

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -177,9 +177,9 @@ async fn run_memory_transport() {
 }
 
 async fn run_ws_tramsport() {
-    let (ws_server, mut connection_listener) = WebSocketServer::new("127.0.0.1:8080");
+    let ws_server = WebSocketServer::new("127.0.0.1:8080");
 
-    ws_server.listen().await.unwrap();
+    let mut connection_listener = ws_server.listen().await.unwrap();
 
     let cancellation_token = CancellationToken::new();
     // Another client to test multiple transports server feature

--- a/justfile
+++ b/justfile
@@ -7,3 +7,4 @@ run-multilang:
   cd examples/integration-multi-lang && cargo run -q > /dev/null &
   sleep 8;
   cd examples/integration-multi-lang/rpc-client-ts && npm i && npm start
+  -@ps aux | grep "cargo run -q" | awk '{print $2}' | tail -1 | xargs kill -9 # kills server

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -242,7 +242,6 @@ impl<Context: Send + Sync + 'static> RpcServer<Context> {
                     }
                     TransportNotification::CloseTransport(id) => {
                         self.transports.remove(&id);
-                        println!("currrent transports: {}", self.transports.len());
                     }
                 },
                 None => {

--- a/rpc/src/transports/memory.rs
+++ b/rpc/src/transports/memory.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use super::{Transport, TransportError, TransportEvent};
 
 pub struct MemoryTransport {
-    id: Option<u32>,
     connected: AtomicBool,
     sender: Sender<Vec<u8>>,
     receiver: Receiver<Vec<u8>>,
@@ -15,7 +14,6 @@ pub struct MemoryTransport {
 impl MemoryTransport {
     fn new(sender: Sender<Vec<u8>>, receiver: Receiver<Vec<u8>>) -> Self {
         Self {
-            id: None,
             sender,
             receiver,
             connected: AtomicBool::new(false),
@@ -65,13 +63,5 @@ impl Transport for MemoryTransport {
 
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
-    }
-
-    fn set_id(&mut self, id: u32) {
-        self.id.replace(id);
-    }
-
-    fn get_id(&self) -> u32 {
-        self.id.unwrap()
     }
 }

--- a/rpc/src/transports/mod.rs
+++ b/rpc/src/transports/mod.rs
@@ -41,8 +41,5 @@ pub trait Transport {
         }
     }
 
-    fn set_id(&mut self, id: u32);
-    fn get_id(&self) -> u32;
-
     fn is_connected(&self) -> bool;
 }

--- a/rpc/src/transports/quic.rs
+++ b/rpc/src/transports/quic.rs
@@ -11,7 +11,6 @@ use tokio::sync::Mutex;
 use super::{Transport, TransportError, TransportEvent};
 
 pub struct QuicTransport {
-    id: Option<u32>,
     send: Mutex<SendStream>,
     receiver: Mutex<RecvStream>,
     ready: AtomicBool,
@@ -20,7 +19,6 @@ pub struct QuicTransport {
 impl QuicTransport {
     fn new((send, receiver): (SendStream, RecvStream)) -> Self {
         Self {
-            id: None,
             send: Mutex::new(send),
             receiver: Mutex::new(receiver),
             ready: AtomicBool::new(false),
@@ -110,13 +108,5 @@ impl Transport for QuicTransport {
 
     fn is_connected(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
-    }
-
-    fn set_id(&mut self, id: u32) {
-        self.id.replace(id);
-    }
-
-    fn get_id(&self) -> u32 {
-        self.id.unwrap()
     }
 }

--- a/rpc/src/transports/web_socket.rs
+++ b/rpc/src/transports/web_socket.rs
@@ -30,7 +30,7 @@ pub struct WebSocketServer {
     address: String,
 }
 
-/// Sender half of a channel to notify the receiver that there is a new connection
+/// Receiver half of a channel to get notified that there is a new connection
 ///
 /// And then attach turn the connection into a transport and attach it to the `RpcServer`
 ///

--- a/rpc/src/transports/web_socket.rs
+++ b/rpc/src/transports/web_socket.rs
@@ -87,12 +87,14 @@ impl WebSocketServer {
                             continue;
                         };
                     }
-                    _ => {
+                    Err(error) => {
                         if tx_on_connection_listener
                             .send(Err(TransportError::Connection))
                             .is_err()
                         {
-                            error!("WS Server: Error on sending the error to the listener")
+                            error!(
+                                "WS Server: Error on sending the error to the listener: {error:?}"
+                            )
                         }
                     }
                 }

--- a/rpc/src/transports/web_socket.rs
+++ b/rpc/src/transports/web_socket.rs
@@ -10,7 +10,10 @@ use async_trait::async_trait;
 use log::{debug, error};
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::Mutex,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
 };
 use tokio_tungstenite::connect_async;
 
@@ -19,47 +22,114 @@ type WriteStream =
 
 type ReadStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// WebSocketServer to receive connections
+pub struct WebSocketServer {
+    /// Address to listen for new connection
+    address: String,
+    /// Sender half of a channel to notify the receiver that there is a new connection
+    ///
+    /// And then attach turn the connection into a transport and attach it to the `RpcServer`
+    ///
+    on_connection_listener: UnboundedSender<Result<Socket, TransportError>>,
+}
+
+impl WebSocketServer {
+    /// Set the configuration and the minimum for a new WebSocket Server
+    pub fn new(address: &str) -> (Self, UnboundedReceiver<Result<Socket, TransportError>>) {
+        let (tx_on_connection_listener, rx_on_connection_listener) = unbounded_channel();
+        (
+            Self {
+                address: address.to_string(),
+                on_connection_listener: tx_on_connection_listener,
+            },
+            rx_on_connection_listener,
+        )
+    }
+
+    /// Listen for new connection on the address given in a background task and send the new connection through the listener in order to handle it.
+    pub async fn listen(&self) -> Result<(), TransportError> {
+        // listen to given address
+        let listener = TcpListener::bind(&self.address).await?;
+        debug!("Listening on: {}", self.address);
+
+        let tx_on_connection_listener = self.on_connection_listener.clone();
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        let peer = if let Ok(perr) = stream.peer_addr() {
+                            perr
+                        } else {
+                            if tx_on_connection_listener
+                                .send(Err(TransportError::Connection))
+                                .is_err()
+                            {
+                                error!("WS Server: Error on sending the error to the listener")
+                            }
+                            continue;
+                        };
+
+                        debug!("Peer address: {}", peer);
+                        let stream = MaybeTlsStream::Plain(stream);
+                        if let Ok(ws) = accept_async(stream).await {
+                            if tx_on_connection_listener.send(Ok(ws)).is_err() {
+                                error!("WS Server: Error on sending the new ws socket to listener")
+                            }
+                        } else {
+                            if tx_on_connection_listener
+                                .send(Err(TransportError::Connection))
+                                .is_err()
+                            {
+                                error!("WS Server: Error on sending the error to the listener")
+                            }
+                            continue;
+                        };
+                    }
+                    _ => {
+                        if tx_on_connection_listener
+                            .send(Err(TransportError::Connection))
+                            .is_err()
+                        {
+                            error!("WS Server: Error on sending the error to the listener")
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+
+/// WebScoketClient structure to connect to a WebSocket Server
+pub struct WebSocketClient;
+
+impl WebSocketClient {
+    /// Connect to a websocket server
+    pub async fn connect(
+        host: &str,
+    ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, TransportError> {
+        let (ws, _) = connect_async(host).await?;
+        debug!("Connected to {}", host);
+        Ok(ws)
+    }
+}
+
 pub struct WebSocketTransport {
-    id: Option<u32>,
     read: Mutex<ReadStream>,
     write: Mutex<WriteStream>,
     ready: AtomicBool,
 }
 
 impl WebSocketTransport {
-    fn create(ws: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
+    pub fn new(ws: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
         let (write, read) = ws.split();
         Self {
-            id: None,
             read: Mutex::new(read),
             write: Mutex::new(write),
             ready: AtomicBool::new(false),
-        }
-    }
-
-    pub async fn connect(address: &str) -> Result<WebSocketTransport, TransportError> {
-        let (ws, _) = connect_async(address).await?;
-        debug!("Connected to {}", address);
-
-        Ok(Self::create(ws))
-    }
-
-    pub async fn listen(address: &str) -> Result<WebSocketTransport, TransportError> {
-        // listen to given address
-        let listener = TcpListener::bind(address).await?;
-        debug!("Listening on: {}", address);
-
-        // wait for a connection
-        match listener.accept().await {
-            Ok((stream, _)) => {
-                let peer = stream.peer_addr()?;
-
-                debug!("Peer address: {}", peer);
-                let stream = MaybeTlsStream::Plain(stream);
-                let ws = accept_async(stream).await?;
-                Ok(Self::create(ws))
-            }
-            _ => Err(TransportError::Connection),
         }
     }
 }
@@ -112,13 +182,5 @@ impl Transport for WebSocketTransport {
 
     fn is_connected(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
-    }
-
-    fn set_id(&mut self, id: u32) {
-        self.id.replace(id);
-    }
-
-    fn get_id(&self) -> u32 {
-        self.id.unwrap()
     }
 }


### PR DESCRIPTION
This PR: 
- includes fixes for issue #44 -> Before this, the `RpcServer` terminates its process when the last client disconnect. 
- includes refactoring for #46 -> Making WS transport flexible and decoupling it so that it can handle more than one connection before this only accepts only one client. Also, this includes some refactoring/changes on attaching a new transport and on each transport itself. 

Closes #44 
Closes #46 