### PR TITLE
fix: add metadata to Cargo.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Install Protobuf
+        run: sudo apt-get install protobuf-compiler
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -2,22 +2,28 @@
 name = "dcl-rpc"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Decentraland RPC Implementation"
+readme = "README.md"
+repository = "https://github.com/decentraland/rpc-rust"
+documentation = "https://docs.rs/dcl-rpc"
+keywords = ["rpc", "decentraland", "protobuffer"]
+categories = ["web-programming", ""]
+license = "Apache-2.0"
+rust-version = "1.65.0"
 
 [dependencies]
-futures-channel.workspace = true
-tokio.workspace = true
-futures-util.workspace = true
-async-trait.workspace = true
-async-channel.workspace = true
-tokio-util.workspace = true
-tokio-tungstenite.workspace = true
-log.workspace = true
-bytes.workspace = true
-prost.workspace = true
-quinn.workspace = true
-rustls.workspace = true
+async-channel = "1.8.0"
+async-trait = "0.1.57"
+bytes = "1.3.0"
+futures-channel = "0.3"
+futures-util = {version = "0.3", default-features = false, features = ["sink", "std"]}
+log = "0.4.17"
+prost = "0.11.5"
+tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
+tokio-tungstenite = "*"
+tokio-util = "0.7.4"
+quinn = "*"
+rustls = { version = "*", features = ["dangerous_configuration", "quic"] }
 
 [build-dependencies]
 prost-build = "0.11.5"


### PR DESCRIPTION
This PR:
- adds metadata to Cargo.toml to be able to publish
- use deps directly instead of `.workspace` syntax because `dcl-rpc` is just published not the entire workspace