### PR TITLE
fix: ws server never finishs listening on port

### DIFF
--- a/examples/integration-multi-lang/src/main.rs
+++ b/examples/integration-multi-lang/src/main.rs
@@ -48,7 +48,7 @@ async fn main() {
 }
 
 async fn run_ws_example() {
-    let ws_server = WebSocketServer::new("127.0.0.1:8080");
+    let mut ws_server = WebSocketServer::new("127.0.0.1:8080");
 
     // Listen in background task
     let mut connection_listener = ws_server.listen().await.unwrap();

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -199,7 +199,7 @@ async fn run_memory_transport() {
 /// This example runs the RpcServer and RpcClients using WebSockets as a transport for messages
 async fn run_ws_transport() {
     // 1. Creates the WebSocket server to listen for WS connections.
-    let ws_server = WebSocketServer::new("127.0.0.1:8080");
+    let mut ws_server = WebSocketServer::new("127.0.0.1:8080");
 
     // 2. Makes the WebSocket server start listening for connections. Not blocking as it'll be listening in the background
     let mut connection_listener = ws_server.listen().await.unwrap();
@@ -281,7 +281,7 @@ async fn run_ws_transport() {
 /// This example wants to show you that it's possible to use multiple type of transports, we don't know if there is a real use case but it's possible.
 async fn run_with_dyn_transport() {
     // 1. Creates the WebSocket server to listen for WS connections.
-    let ws_server = WebSocketServer::new("127.0.0.1:8080");
+    let mut ws_server = WebSocketServer::new("127.0.0.1:8080");
 
     // 2. Makes the WebSocket server start listening for connections. Not blocking as it'll be listening in the background
     let mut connection_listener = ws_server.listen().await.unwrap();

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -117,6 +117,10 @@ async fn main() {
         run_memory_transport().await;
         println!("--- Running example with Web Socket Transports ---");
         run_ws_transport().await;
+        // Giving time to the OS to terminate the binding to the 8080 port used by the both examples.
+        // The listener abort on dropping the ws server.
+        sleep(Duration::from_secs(1)).await;
+        //
         println!("--- Running example with &dyn Transport ---");
         run_with_dyn_transport().await;
         // TODO: fix QUIC transport (similar to ws fix)


### PR DESCRIPTION
This PR:
- fixes conflicting examples. the WebSocket server keeps listening on the port even though the prev example is finished. Now, the ws server stops listening on its drop. 