### PR TITLE
chore: adding cargo features and protobuf-src

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # dcl-rpc
 
-[![Build](https://github.com/decentraland/rpc-rust/workflows/Validations/badge.svg)](
-<https://github.com/decentraland/rpc-rust/actions>)
-[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](
-<https://github.com/decentraland/rpc-rust>)
-[![Cargo](https://img.shields.io/crates/v/dcl-rpc.svg)](
-<https://crates.io/crates/dcl-rpc>)
-[![Documentation](https://docs.rs/dcl-rpc/badge.svg)](
-<https://docs.rs/dcl-rpc>)
+[![Build](https://github.com/decentraland/rpc-rust/workflows/Validations/badge.svg)](https://github.com/decentraland/rpc-rust/actions)
+[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](https://github.com/decentraland/rpc-rust)
+[![Cargo](https://img.shields.io/crates/v/dcl-rpc.svg)](https://crates.io/crates/dcl-rpc)
+[![Documentation](https://docs.rs/dcl-rpc/badge.svg)](https://docs.rs/dcl-rpc)
 
 The Rust implementation of Decentraland RPC. At Decentraland, we have our own implementation of RPC for communications between the different services.
 
@@ -17,20 +13,6 @@ Currently, there are other implementations:
 - [C#](https://github.com/decentraland/rpc-csharp)
 
 ## Requirements
-
-- Install protoc binaries
-
-### MacOS
-
-```bash
-brew install protobuf
-```
-
-### Debian-based Linux
-
-```bash
-sudo apt-get install protobuf-compiler
-```
 
 - Install Just
 
@@ -48,13 +30,13 @@ RPC Client in Rust and RPC Server in Rust running Websocket transport example, M
 
 `just run-integration`
 
-### Run the integration example with an specific transport 
+### Run the integration example with an specific transport
 
 RPC Client in Rust and RPC Server in Rust running the example passed to the command
 
 `just run-integration {ws|memory|dyn}`
 
-### Run the multi language integration example 
+### Run the multi language integration example
 
 RPC Client in Typescript and RPC Server in Rust using WebSockets
 
@@ -108,11 +90,12 @@ fn main() -> Result<()> {
 }
 ```
 
-The `build.rs` script runs every time that your `.proto` changes. The script will generate a file in the `OUT_DIR`, named as the `package` field in the `.proto` file (if it's not declared, the name will be '_.rs'). This file will include: 
-- All your declared messages in the `.proto` as Rust structs. *1
-- A trait, named `{YOUR_RPC_SERVICE_NAME}Server`, with the methods defined in your service for the server side. So you should use this trait to build an implementation with the business logic. *2
-- A trait, named `RpcServiceClient`, and an implementation of it for the client side, named `{YOUR_RPC_SERVICE_NAME}Client`. You must use this auto-generated implementation when using the `RpcClient` passing the implementation (struct with the trait implemented) as a generic in the `load_module` function, which it'll be in charge of requesting the procedures of your service. *3
-- A struct in charge of registering your declared service when a `RpcServerPort` is created. You should use this struct and its registering function inside the `RpcServer` port creation handler. *4
+The `build.rs` script runs every time that your `.proto` changes. The script will generate a file in the `OUT_DIR`, named as the `package` field in the `.proto` file (if it's not declared, the name will be '\_.rs'). This file will include:
+
+- All your declared messages in the `.proto` as Rust structs. \*1
+- A trait, named `{YOUR_RPC_SERVICE_NAME}Server`, with the methods defined in your service for the server side. So you should use this trait to build an implementation with the business logic. \*2
+- A trait, named `RpcServiceClient`, and an implementation of it for the client side, named `{YOUR_RPC_SERVICE_NAME}Client`. You must use this auto-generated implementation when using the `RpcClient` passing the implementation (struct with the trait implemented) as a generic in the `load_module` function, which it'll be in charge of requesting the procedures of your service. \*3
+- A struct in charge of registering your declared service when a `RpcServerPort` is created. You should use this struct and its registering function inside the `RpcServer` port creation handler. \*4
 
 To import them you must add:
 
@@ -126,8 +109,8 @@ This statement should be added to the `src/lib.rs` in order to make the auto-gen
 
 ```rust
 use dcl_rpc::{
-    transports::web_socket::{WebSocketServer, WebSocketTransport}, 
-    server::{RpcServer, RpcServerPort}, 
+    transports::web_socket::{WebSocketServer, WebSocketTransport},
+    server::{RpcServer, RpcServerPort},
     service_module_definition::{Definition, ServiceModuleDefinition, CommonPayload}
 };
 
@@ -176,7 +159,7 @@ Implement the trait for your service
 
 ```rust
 use crate::{
-    MyExampleContext, 
+    MyExampleContext,
     EchoServiceServer, // (*2)
     Text // (*1) message
 };

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dcl-rpc = { path = "../../rpc"}
+dcl-rpc = { path = "../../rpc", features = ["quic"] }
 futures-channel= { workspace = true }
 tokio= { workspace = true }
 futures-util= { workspace = true }

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dcl-rpc = { path = "../../rpc", features = ["quic"] }
+dcl-rpc = { path = "../../rpc", features = ["client", "quic"] }
 futures-channel= { workspace = true }
 tokio= { workspace = true }
 futures-util= { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,16 +19,21 @@ futures-util = {version = "0.3", default-features = false, features = ["sink", "
 log = "0.4.17"
 prost = "0.11.5"
 tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
-tokio-tungstenite = "0.18.0"
+tokio-tungstenite = { version = "0.18.0", optional = true }
 tokio-util = "0.7.4"
-quinn = "0.9.3"
-rustls = { version = "0.20.8", features = ["dangerous_configuration", "quic"] }
-proc-macro2 = { version = "1.0" }
-quote = { version = "1.0" }
-prost-build = "0.11.5"
+quinn = { version = "0.9.3", optional = true }
+rustls = { version = "0.20.8", optional = true, features = ["dangerous_configuration", "quic"] }
+proc-macro2 = { version = "1.0", optional = true }
+quote = { version = "1.0", optional = true }
+prost-build = { version = "0.11.5", optional = true }
 
 [build-dependencies]
 prost-build = "0.11.5"
+protobuf-src = "1.1.0"
 
-[dev-dependencies]
-prost-build = "0.11.5"
+[features]
+default = ["codegen", "memory", "websockets"]
+codegen = ["dep:quote", "dep:prost-build", "dep:proc-macro2"]
+memory = []
+websockets = ["dep:tokio-tungstenite"]
+quic = ["dep:quinn", "dep:rustls"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -32,8 +32,10 @@ prost-build = "0.11.5"
 protobuf-src = "1.1.0"
 
 [features]
-default = ["codegen", "memory", "websockets"]
+default = ["codegen", "memory", "websockets", "server"]
 codegen = ["dep:quote", "dep:prost-build", "dep:proc-macro2"]
 memory = []
 websockets = ["dep:tokio-tungstenite"]
 quic = ["dep:quinn", "dep:rustls"]
+client = []
+server = []

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -2,6 +2,7 @@ extern crate prost_build;
 use std::io::Result;
 
 fn main() -> Result<()> {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed=src/rpc_protocol/index.proto");
 

--- a/rpc/src/codegen.rs
+++ b/rpc/src/codegen.rs
@@ -473,9 +473,13 @@ fn extract_body_token(params: MethodSigTokensParams) -> TokenStream {
 impl ServiceGenerator for RPCServiceGenerator {
     fn generate(&mut self, service: Service, buf: &mut String) {
         self.generate_stream_types(buf);
+        #[cfg(feature = "client")]
         self.generate_client_trait(&service, buf);
+        #[cfg(feature = "client")]
         self.generate_client_service(&service, buf);
+        #[cfg(feature = "server")]
         self.generate_server_trait(&service, buf);
+        #[cfg(feature = "server")]
         self.generate_server_service(&service, buf);
         println!("{}", buf);
     }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -20,11 +20,13 @@
 //! You could find basic and complex examples in the [examples folder](https://github.com/decentraland/rpc-rust/tree/main/examples) on the [github repository](https://github.com/decentraland/rpc-rust).
 //!
 
+#[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "codegen")]
 pub mod codegen;
 pub mod messages_handlers;
 pub mod rpc_protocol;
+#[cfg(feature = "server")]
 pub mod server;
 pub mod service_module_definition;
 pub mod stream_protocol;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -21,6 +21,7 @@
 //!
 
 pub mod client;
+#[cfg(feature = "codegen")]
 pub mod codegen;
 pub mod messages_handlers;
 pub mod rpc_protocol;

--- a/rpc/src/transports/error.rs
+++ b/rpc/src/transports/error.rs
@@ -1,7 +1,9 @@
 //! Contains the parsing methods for the errors of the current transports.
 use std::{io, net::AddrParseError};
 
+#[cfg(feature = "quic")]
 use quinn::{ConnectError, ConnectionError, WriteError};
+#[cfg(feature = "websockets")]
 use tokio_tungstenite::tungstenite;
 
 use super::TransportError;
@@ -12,12 +14,14 @@ impl From<io::Error> for TransportError {
     }
 }
 
+#[cfg(feature = "quic")]
 impl From<ConnectError> for TransportError {
     fn from(_value: ConnectError) -> Self {
         TransportError::Internal
     }
 }
 
+#[cfg(feature = "quic")]
 impl From<ConnectionError> for TransportError {
     fn from(_value: ConnectionError) -> Self {
         TransportError::Internal
@@ -30,12 +34,14 @@ impl From<AddrParseError> for TransportError {
     }
 }
 
+#[cfg(feature = "quic")]
 impl From<WriteError> for TransportError {
     fn from(_value: WriteError) -> Self {
         TransportError::Connection
     }
 }
 
+#[cfg(feature = "websockets")]
 impl From<tungstenite::Error> for TransportError {
     fn from(_value: tungstenite::Error) -> Self {
         TransportError::Internal

--- a/rpc/src/transports/mod.rs
+++ b/rpc/src/transports/mod.rs
@@ -5,8 +5,11 @@
 use async_trait::async_trait;
 
 pub mod error;
+#[cfg(feature = "memory")]
 pub mod memory;
+#[cfg(feature = "quic")]
 pub mod quic;
+#[cfg(feature = "websockets")]
 pub mod web_socket;
 
 #[derive(Debug)]


### PR DESCRIPTION
## Description

- Adds cargo features so consumers don't have all dependencies and just the required.
- Adds `protobuf-src` dependency to avoid external `protoc` installation

Closes #56 