### PR TITLE
fix: change server's state after sending

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-rpc"
-version = "2.0.1"
+version = "2.1.1"
 edition = "2021"
 description = "Decentraland RPC Implementation"
 repository = "https://github.com/decentraland/rpc-rust"

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -785,6 +785,8 @@ pub struct RpcServerPort<Context> {
     loaded_modules: HashMap<String, ServerModuleDeclaration>,
     /// Procedures contains the id and the handler for each procedure
     procedures: HashMap<u32, ProcedureDefinition<Context>>,
+    /// Global Procedure ID
+    next_procedure_id: u32,
 }
 
 impl<Context> RpcServerPort<Context> {
@@ -794,6 +796,7 @@ impl<Context> RpcServerPort<Context> {
             registered_modules: HashMap::new(),
             loaded_modules: HashMap::new(),
             procedures: HashMap::new(),
+            next_procedure_id: 1,
         }
     }
 
@@ -827,10 +830,9 @@ impl<Context> RpcServerPort<Context> {
                     };
 
                     let definitions = module_generator.get_definitions();
-                    let mut procedure_id = 1;
 
                     for (procedure_name, procedure_definition) in definitions {
-                        let current_id = procedure_id;
+                        let current_id = self.next_procedure_id;
                         self.procedures
                             .insert(current_id, procedure_definition.clone());
                         server_module_declaration
@@ -839,7 +841,7 @@ impl<Context> RpcServerPort<Context> {
                                 procedure_name: procedure_name.clone(),
                                 procedure_id: current_id,
                             });
-                        procedure_id += 1
+                        self.next_procedure_id += 1;
                     }
 
                     self.loaded_modules


### PR DESCRIPTION
This PR:
- change the server's state after sending successfully through the transport
- global ID for procedures from different services
- bump version