### PR TITLE
chore: remove protobuf-src dependency as it takes too long to build

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -30,7 +30,6 @@ warp = { version = "0.3.3", optional = true }
 
 [build-dependencies]
 prost-build = "0.11.5"
-protobuf-src = "1.1.0"
 
 [features]
 default = ["codegen", "memory", "websockets", "server"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcl-rpc"
-version = "2.3.4"
+version = "2.3.5"
 edition = "2021"
 description = "Decentraland RPC Implementation"
 repository = "https://github.com/decentraland/rpc-rust"

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -2,7 +2,6 @@ extern crate prost_build;
 use std::io::Result;
 
 fn main() -> Result<()> {
-    std::env::set_var("PROTOC", protobuf_src::protoc());
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed=src/rpc_protocol/index.proto");
 


### PR DESCRIPTION
## Description

Removes `protobuf-src` dependency as it takes too long to build