### PR TITLE
chore: bump tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ futures-util = {version = "0.3", default-features = false, features = ["sink", "
 log = "0.4.17"
 prost = "0.11.5"
 tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
-tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 tokio-util = "0.7.4"
 rcgen = "0.10.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = {version = "0.3", default-features = false, features = ["sink", "
 tokio = {version = "1.0.0", default-features = false, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "time", "sync"]}
 tokio-util = "0.7.4"
 
-tokio-tungstenite = { version = "0.18.0", features = ["native-tls"], optional = true }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 quote = { version = "1.0", optional = true }
 prost-build = { version = "0.11.5", optional = true }


### PR DESCRIPTION
bump to fix a [dos](https://github.com/decentraland/bevy-explorer/security/dependabot/2) vulnerability.

the project tests pass, and client side has been tested in bevy-explorer.